### PR TITLE
Fix GetAllEpisodes breaking library scan on missing Episode Data

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbMissingEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbMissingEpisodeProvider.cs
@@ -328,7 +328,8 @@ namespace Jellyfin.Plugin.Tvdb.Providers
 
                     if (episodes.Data == null)
                     {
-                        throw new TvDbServerException($"Episode Query returned null for tvdbId: {tvdbId}", -1);
+                        _logger.LogWarning("Unable to get episodes from TVDB: Episode Query returned null for TVDB Id: {TvdbId}", tvdbId);
+                        return Array.Empty<EpisodeRecord>();
                     }
 
                     allEpisodes.AddRange(episodes.Data);

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbMissingEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbMissingEpisodeProvider.cs
@@ -325,6 +325,12 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                         episodeQuery,
                         acceptedLanguage,
                         CancellationToken.None).ConfigureAwait(false);
+
+                    if (episodes.Data == null)
+                    {
+                        throw new TvDbServerException($"Episode Query returned null for tvdbId: {tvdbId}", -1);
+                    }
+
                     allEpisodes.AddRange(episodes.Data);
                     if (!episodes.Links.Next.HasValue)
                     {


### PR DESCRIPTION
This fixes an issue where if `episodes.Data` returns `null`, the whole library scan would break due to an `ArgumentNullException`.

Fixes #70, jellyfin/jellyfin#8989