### PR TITLE
Replace PersonType with PersonKind

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
@@ -254,7 +254,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                 result.AddPerson(new PersonInfo
                 {
                     Name = director,
-                    Type = PersonType.Director
+                    Type = PersonKind.Director
                 });
             }
 
@@ -274,7 +274,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                 {
                     result.AddPerson(new PersonInfo
                     {
-                        Type = PersonType.GuestStar,
+                        Type = PersonKind.GuestStar,
                         Name = currentActor,
                         Role = string.Empty
                     });
@@ -303,7 +303,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
 
                 result.AddPerson(new PersonInfo
                 {
-                    Type = PersonType.GuestStar,
+                    Type = PersonKind.GuestStar,
                     Name = currentActor.Substring(0, roleStartIndex).Trim(),
                     Role = string.Join(", ", roles)
                 });
@@ -314,7 +314,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                 result.AddPerson(new PersonInfo
                 {
                     Name = writer,
-                    Type = PersonType.Writer
+                    Type = PersonKind.Writer
                 });
             }
 


### PR DESCRIPTION
I seem to be getting some errors on my end of the pluging saying these fields are strings, but I noticed in march these were changed to `PersonKind`s instead. 

https://github.com/jellyfin/jellyfin/blob/master/Jellyfin.Data/Enums/PersonKind.cs

The commit looks like it was from 6 months ago, so I figured to try and fix the plugin.

Not sure how to test if this works (other than making the plugin and installing it myself)