### PR TITLE
Fixes for tvdb v4 migration

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
@@ -212,8 +212,8 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                     AirsBeforeSeasonNumber = episode.AirsBeforeSeason,
                     // Tvdb uses 3 letter code for language (prob ISO 639-2)
                     // Reverts to OriginalName if no translation is found
-                    Name = episode.Translations.NameTranslations.FirstOrDefault(x => string.Equals(x.Language, TvdbUtils.NormalizeLanguageToTvdb(id.MetadataLanguage), StringComparison.OrdinalIgnoreCase))?.Name ?? episode.Name,
-                    Overview = episode.Translations.OverviewTranslations?.FirstOrDefault(x => string.Equals(x.Language, TvdbUtils.NormalizeLanguageToTvdb(id.MetadataLanguage), StringComparison.OrdinalIgnoreCase))?.Overview ?? episode.Overview
+                    Name = episode.Translations.GetTranslatedNamedOrDefault(id.MetadataLanguage) ?? episode.Name,
+                    Overview = episode.Translations.GetTranslatedOverviewOrDefault(id.MetadataLanguage) ?? episode.Overview
                 }
             };
             result.ResetPeople();

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbMissingEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbMissingEpisodeProvider.cs
@@ -4,12 +4,10 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Jellyfin.Data.Entities.Libraries;
 using Jellyfin.Data.Events;
 using MediaBrowser.Controller.BaseItemManager;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
-using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Plugins;
 using MediaBrowser.Controller.Providers;
@@ -202,17 +200,17 @@ namespace Jellyfin.Plugin.Tvdb.Providers
             var tvdbId = Convert.ToInt32(tvdbIdTxt, CultureInfo.InvariantCulture);
             var allEpisodes = await GetAllEpisodes(tvdbId, season.GetPreferredMetadataLanguage()).ConfigureAwait(false);
 
+            var seasonEpisodes = allEpisodes.Where(e => e.SeasonNumber == season.IndexNumber).ToList();
             var existingEpisodes = season.Children.OfType<Episode>().ToList();
 
-            for (var i = 0; i < allEpisodes.Count; i++)
+            foreach (var episodeRecord in seasonEpisodes)
             {
-                var episode = allEpisodes[i];
-                if (EpisodeExists(episode, existingEpisodes))
+                if (EpisodeExists(episodeRecord, existingEpisodes))
                 {
                     continue;
                 }
 
-                AddVirtualEpisode(episode, season);
+                AddVirtualEpisode(episodeRecord, season);
             }
         }
 
@@ -295,7 +293,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                 EpisodeBaseRecord? episodeRecord = null;
                 if (episodeRecords.Count > 0)
                 {
-                    episodeRecord = episodeRecords[0];
+                    episodeRecord = episodeRecords.FirstOrDefault(e => EpisodeEquals(episode, e));
                 }
 
                 AddVirtualEpisode(episodeRecord, episode.Season);

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbMissingEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbMissingEpisodeProvider.cs
@@ -99,7 +99,13 @@ namespace Jellyfin.Plugin.Tvdb.Providers
 
         private static bool EpisodeExists(EpisodeBaseRecord episodeRecord, IReadOnlyList<Episode> existingEpisodes)
         {
-            return existingEpisodes.Any(ep => ep.ContainsEpisodeNumber(episodeRecord.Number) && ep.ParentIndexNumber == episodeRecord.Number);
+            return existingEpisodes.Any(episode => EpisodeEquals(episode, episodeRecord));
+        }
+
+        private static bool EpisodeEquals(Episode episode, EpisodeBaseRecord otherEpisodeRecord)
+        {
+            return episode.ContainsEpisodeNumber(otherEpisodeRecord.Number)
+                && episode.ParentIndexNumber == otherEpisodeRecord.SeasonNumber;
         }
 
         private bool IsEnabledForLibrary(BaseItem item)

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbSeriesProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbSeriesProvider.cs
@@ -272,7 +272,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                         .ConfigureAwait(false);
             var resultData = result;
 
-            if (resultData == null || resultData.Count == 0)
+            if (resultData is null || resultData.Count == 0 || resultData[0] is null || resultData[0].Series is null)
             {
                 _logger.LogWarning("TvdbSearch: No series found for id: {0}", id);
                 return null;

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbSeriesProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbSeriesProvider.cs
@@ -467,8 +467,8 @@ namespace Jellyfin.Plugin.Tvdb.Providers
             series.SetProviderId(TvdbPlugin.ProviderId, tvdbSeries.Id.ToString(CultureInfo.InvariantCulture));
             // Tvdb uses 3 letter code for language (prob ISO 639-2)
             // Reverts to OriginalName if no translation is found
-            series.Name = tvdbSeries.Translations.NameTranslations.FirstOrDefault(x => string.Equals(x.Language, TvdbUtils.NormalizeLanguageToTvdb(info.MetadataLanguage), StringComparison.OrdinalIgnoreCase))?.Name ?? tvdbSeries.Name;
-            series.Overview = tvdbSeries.Translations.OverviewTranslations.FirstOrDefault(x => string.Equals(x.Language, TvdbUtils.NormalizeLanguageToTvdb(info.MetadataLanguage), StringComparison.OrdinalIgnoreCase))?.Overview ?? tvdbSeries.Overview;
+            series.Name = tvdbSeries.Translations.GetTranslatedNamedOrDefault(info.MetadataLanguage) ?? tvdbSeries.Name;
+            series.Overview = tvdbSeries.Translations.GetTranslatedOverviewOrDefault(info.MetadataLanguage) ?? tvdbSeries.Overview;
             series.OriginalTitle = tvdbSeries.Name;
             result.ResultLanguage = info.MetadataLanguage;
             series.AirDays = TvdbUtils.GetAirDays(tvdbSeries.AirsDays).ToArray();

--- a/Jellyfin.Plugin.Tvdb/TvdbSdkExtensions.cs
+++ b/Jellyfin.Plugin.Tvdb/TvdbSdkExtensions.cs
@@ -1,0 +1,39 @@
+using System.Linq;
+
+using Jellyfin.Extensions;
+
+using Tvdb.Sdk;
+
+namespace Jellyfin.Plugin.Tvdb;
+
+/// <summary>
+/// Extension Methods for Tvdb SDK.
+/// </summary>
+public static class TvdbSdkExtensions
+{
+    /// <summary>
+    /// Get the translated Name, or <see langword="null"/>.
+    /// </summary>
+    /// <param name="translations">Available translations.</param>
+    /// <param name="language">Requested language.</param>
+    /// <returns>Translated Name, or <see langword="null"/>.</returns>
+    public static string? GetTranslatedNamedOrDefault(this TranslationExtended? translations, string? language)
+    {
+        return translations?
+            .NameTranslations
+            .FirstOrDefault(translation => TvdbUtils.MatchLanguage(language, translation.Language))?.Name;
+    }
+
+    /// <summary>
+    /// Get the translated Overview, or <see langword="null"/>.
+    /// </summary>
+    /// <param name="translations">Available translations.</param>
+    /// <param name="language">Requested language.</param>
+    /// <returns>Translated Overview, or <see langword="null"/>.</returns>
+    public static string? GetTranslatedOverviewOrDefault(this TranslationExtended? translations, string? language)
+    {
+        return translations?
+            .OverviewTranslations
+            .FirstOrDefault(translation => TvdbUtils.MatchLanguage(language, translation.Language))?.Overview;
+    }
+}

--- a/Jellyfin.Plugin.Tvdb/TvdbUtils.cs
+++ b/Jellyfin.Plugin.Tvdb/TvdbUtils.cs
@@ -1,5 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Linq;
+
 using MediaBrowser.Model.Entities;
 using Tvdb.Sdk;
 
@@ -39,31 +41,32 @@ namespace Jellyfin.Plugin.Tvdb
         }
 
         /// <summary>
-        /// Normalize language to tvdb format.
+        /// Try to find a match for input language.
         /// </summary>
-        /// <param name="language">Language.</param>
+        /// <param name="language">input Language.</param>
+        /// <param name="tvdbLanguage">TVDB data language.</param>
         /// <returns>Normalized language.</returns>
-        public static string? NormalizeLanguageToTvdb(string? language)
+        public static bool MatchLanguage(string? language, string tvdbLanguage)
         {
             if (string.IsNullOrWhiteSpace(language))
             {
-                return null;
+                return false;
             }
 
             // Unique case for zh-TW
             if (string.Equals(language, "zh-TW", StringComparison.OrdinalIgnoreCase))
             {
-                return "zhtw";
+                language = "zhtw";
             }
 
             // Unique case for pt-BR
             if (string.Equals(language, "pt-br", StringComparison.OrdinalIgnoreCase))
             {
-                return "pt";
+                language = "pt";
             }
 
-            // to (ISO 639-2)
-            return TvdbCultureInfo.GetCultureInfo(language)?.ThreeLetterISOLanguageName;
+            // try to find a match (ISO 639-2)
+            return TvdbCultureInfo.GetCultureInfo(language)?.ThreeLetterISOLanguageNames?.Contains(tvdbLanguage, StringComparer.OrdinalIgnoreCase) ?? false;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds some fixes for #93 in `TvdbMissingEpisodeProvider`
- Comparing Episodes compares SeasonNumber with Episode Number `episode.ParentIndexNumber == otherEpisodeRecord.Number` instead of `episode.ParentIndexNumber == otherEpisodeRecord.SeasonNumber`
- Translation does not handle the case where two three letter codes are available
- filtering for episodes of a season was removed with api change