### PR TITLE
Make Tvdb Client usage more resilient and robust

### DIFF
--- a/Jellyfin.Plugin.Tvdb/CollectionExtensions.cs
+++ b/Jellyfin.Plugin.Tvdb/CollectionExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.Tvdb;
+
+internal static class CollectionExtensions
+{
+    /// <summary>
+    /// Adds the <paramref name="item"/> if it is not <see langword="null"/>.
+    /// </summary>
+    /// <typeparam name="T">Data type of the collection items.</typeparam>
+    /// <param name="collection">Input <see cref="ICollection"/>.</param>
+    /// <param name="item">Item to add.</param>
+    /// <returns>The input collection.</returns>
+    public static ICollection<T> AddIfNotNull<T>(this ICollection<T> collection, T? item)
+    {
+        if (item != null)
+        {
+            collection.Add(item);
+        }
+
+        return collection;
+    }
+}

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeImageProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeImageProvider.cs
@@ -4,14 +4,15 @@ using System.Globalization;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
+
 using Microsoft.Extensions.Logging;
-using Tvdb.Sdk;
 
 namespace Jellyfin.Plugin.Tvdb.Providers
 {
@@ -94,11 +95,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                             .GetEpisodesAsync(Convert.ToInt32(episodeTvdbId, CultureInfo.InvariantCulture), language, cancellationToken)
                             .ConfigureAwait(false);
 
-                    var image = GetImageInfo(episodeResult);
-                    if (image != null)
-                    {
-                        imageResult.Add(image);
-                    }
+                    imageResult.AddIfNotNull(episodeResult.CreateImageInfo(Name));
                 }
                 catch (Exception e)
                 {
@@ -113,21 +110,6 @@ namespace Jellyfin.Plugin.Tvdb.Providers
         public Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)
         {
             return _httpClientFactory.CreateClient(NamedClient.Default).GetAsync(new Uri(url), cancellationToken);
-        }
-
-        private RemoteImageInfo? GetImageInfo(EpisodeExtendedRecord episode)
-        {
-            if (string.IsNullOrEmpty(episode.Image))
-            {
-                return null;
-            }
-
-            return new RemoteImageInfo
-            {
-                ProviderName = Name,
-                Url = episode.Image,
-                Type = ImageType.Primary
-            };
         }
     }
 }

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbSeasonImageProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbSeasonImageProvider.cs
@@ -3,135 +3,132 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.Providers;
+
 using Microsoft.Extensions.Logging;
+
 using Tvdb.Sdk;
-using RatingType = MediaBrowser.Model.Dto.RatingType;
 
-namespace Jellyfin.Plugin.Tvdb.Providers
+namespace Jellyfin.Plugin.Tvdb.Providers;
+
+/// <summary>
+/// Tvdb season image provider.
+/// </summary>
+public class TvdbSeasonImageProvider : IRemoteImageProvider
 {
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<TvdbSeasonImageProvider> _logger;
+    private readonly TvdbClientManager _tvdbClientManager;
+
     /// <summary>
-    /// Tvdb season image provider.
+    /// Initializes a new instance of the <see cref="TvdbSeasonImageProvider"/> class.
     /// </summary>
-    public class TvdbSeasonImageProvider : IRemoteImageProvider
+    /// <param name="httpClientFactory">Instance of the <see cref="IHttpClientFactory"/> interface.</param>
+    /// <param name="logger">Instance of the <see cref="ILogger{TvdbSeasonImageProvider}"/> interface.</param>
+    /// <param name="tvdbClientManager">Instance of <see cref="TvdbClientManager"/>.</param>
+    public TvdbSeasonImageProvider(
+        IHttpClientFactory httpClientFactory,
+        ILogger<TvdbSeasonImageProvider> logger,
+        TvdbClientManager tvdbClientManager)
     {
-        private readonly IHttpClientFactory _httpClientFactory;
-        private readonly ILogger<TvdbSeasonImageProvider> _logger;
-        private readonly TvdbClientManager _tvdbClientManager;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+        _tvdbClientManager = tvdbClientManager;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TvdbSeasonImageProvider"/> class.
-        /// </summary>
-        /// <param name="httpClientFactory">Instance of the <see cref="IHttpClientFactory"/> interface.</param>
-        /// <param name="logger">Instance of the <see cref="ILogger{TvdbSeasonImageProvider}"/> interface.</param>
-        /// <param name="tvdbClientManager">Instance of <see cref="TvdbClientManager"/>.</param>
-        public TvdbSeasonImageProvider(IHttpClientFactory httpClientFactory, ILogger<TvdbSeasonImageProvider> logger, TvdbClientManager tvdbClientManager)
+    /// <inheritdoc />
+    public string Name => TvdbPlugin.ProviderName;
+
+    /// <inheritdoc />
+    public bool Supports(BaseItem item)
+    {
+        return item is Season;
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<ImageType> GetSupportedImages(BaseItem item)
+    {
+        yield return ImageType.Primary;
+        yield return ImageType.Banner;
+        yield return ImageType.Backdrop;
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<RemoteImageInfo>> GetImages(BaseItem item, CancellationToken cancellationToken)
+    {
+        var season = (Season)item;
+        var series = season.Series;
+
+        if (series == null || !season.IndexNumber.HasValue || !TvdbSeriesProvider.IsValidSeries(series.ProviderIds))
         {
-            _httpClientFactory = httpClientFactory;
-            _logger = logger;
-            _tvdbClientManager = tvdbClientManager;
+            return Enumerable.Empty<RemoteImageInfo>();
         }
 
-        /// <inheritdoc />
-        public string Name => TvdbPlugin.ProviderName;
+        var languages = await _tvdbClientManager.GetLanguagesAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var languageLookup = languages
+            .ToDictionary(l => l.Id, StringComparer.OrdinalIgnoreCase);
 
-        /// <inheritdoc />
-        public bool Supports(BaseItem item)
+        var artworkTypes = await _tvdbClientManager.GetArtworkTypeAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var seasonArtworkTypeLookup = artworkTypes
+            .Where(t => string.Equals(t.RecordType, "season", StringComparison.OrdinalIgnoreCase))
+            .ToDictionary(t => t.Id);
+
+        var seriesTvdbId = Convert.ToInt32(series.GetProviderId(TvdbPlugin.ProviderId), CultureInfo.InvariantCulture);
+        var seasonNumber = season.IndexNumber.Value;
+
+        var seasonArtworks = await GetSeasonArtworks(seriesTvdbId, seasonNumber, cancellationToken)
+            .ConfigureAwait(false);
+
+        var remoteImages = new List<RemoteImageInfo>();
+        foreach (var artwork in seasonArtworks)
         {
-            return item is Season;
+            var artworkType = seasonArtworkTypeLookup.GetValueOrDefault(artwork.Type);
+            var imageType = artworkType.GetImageType();
+            var artworkLanguage = artwork.Language is null ? null : languageLookup.GetValueOrDefault(artwork.Language);
+
+            // only add if valid RemoteImageInfo
+            remoteImages.AddIfNotNull(artwork.CreateImageInfo(Name, imageType, artworkLanguage));
         }
 
-        /// <inheritdoc />
-        public IEnumerable<ImageType> GetSupportedImages(BaseItem item)
+        return remoteImages.OrderByLanguageDescending(item.GetPreferredMetadataLanguage());
+    }
+
+    private async Task<IReadOnlyList<ArtworkBaseRecord>> GetSeasonArtworks(int seriesTvdbId, int seasonNumber, CancellationToken cancellationToken)
+    {
+        try
         {
-            yield return ImageType.Primary;
-            yield return ImageType.Banner;
-            yield return ImageType.Backdrop;
-        }
-
-        /// <inheritdoc />
-        public async Task<IEnumerable<RemoteImageInfo>> GetImages(BaseItem item, CancellationToken cancellationToken)
-        {
-            var season = (Season)item;
-            var series = season.Series;
-
-            if (series == null || !season.IndexNumber.HasValue || !TvdbSeriesProvider.IsValidSeries(series.ProviderIds))
-            {
-                return Enumerable.Empty<RemoteImageInfo>();
-            }
-
-            var tvdbId = Convert.ToInt32(series.GetProviderId(TvdbPlugin.ProviderId), CultureInfo.InvariantCulture);
-            var seasonNumber = season.IndexNumber.Value;
-            var language = item.GetPreferredMetadataLanguage();
-            var remoteImages = new List<RemoteImageInfo>();
-            var seriesInfo = await _tvdbClientManager.GetSeriesExtendedByIdAsync(tvdbId, language, cancellationToken, small: true).ConfigureAwait(false);
+            var seriesInfo = await _tvdbClientManager.GetSeriesExtendedByIdAsync(seriesTvdbId, string.Empty, cancellationToken, small: true)
+                .ConfigureAwait(false);
             var seasonTvdbId = seriesInfo.Seasons.FirstOrDefault(s => s.Number == seasonNumber)?.Id;
 
-            var seasonInfo = await _tvdbClientManager.GetSeasonByIdAsync(Convert.ToInt32(seasonTvdbId, CultureInfo.InvariantCulture), language, cancellationToken).ConfigureAwait(false);
-            var seasonImages = seasonInfo.Artwork;
-            var languages = _tvdbClientManager.GetLanguagesAsync(CancellationToken.None).Result;
-            var artworkTypes = _tvdbClientManager.GetArtworkTypeAsync(CancellationToken.None).Result;
-
-            foreach (var image in seasonImages)
-            {
-                ImageType type;
-                // Checks if valid image type, if not, skip
-                try
-                {
-                    type = TvdbUtils.GetImageTypeFromKeyType(artworkTypes.FirstOrDefault(x => x.Id == image.Type && string.Equals(x.RecordType, "season", StringComparison.OrdinalIgnoreCase))?.Name);
-                }
-                catch (Exception)
-                {
-                    continue;
-                }
-
-                var imageInfo = new RemoteImageInfo
-                {
-                    RatingType = RatingType.Score,
-                    Url = image.Image,
-                    Width = Convert.ToInt32(image.Width, CultureInfo.InvariantCulture),
-                    Height = Convert.ToInt32(image.Height, CultureInfo.InvariantCulture),
-                    Type = type,
-                    ProviderName = Name,
-                    ThumbnailUrl = image.Thumbnail
-                };
-
-                // Tvdb uses 3 letter code for language (prob ISO 639-2)
-                var artworkLanguage = languages.FirstOrDefault(lang => string.Equals(lang.Id, image.Language, StringComparison.OrdinalIgnoreCase))?.Id;
-                if (!string.IsNullOrEmpty(artworkLanguage))
-                {
-                    imageInfo.Language = TvdbUtils.NormalizeLanguageToJellyfin(artworkLanguage)?.ToLowerInvariant();
-                }
-
-                remoteImages.Add(imageInfo);
-            }
-
-            return remoteImages.OrderByDescending(i =>
-            {
-                if (string.Equals(language, i.Language, StringComparison.OrdinalIgnoreCase))
-                {
-                    return 2;
-                }
-                else if (!string.IsNullOrEmpty(i.Language))
-                {
-                    return 1;
-                }
-
-                return 0;
-            });
+            var seasonInfo = await _tvdbClientManager.GetSeasonByIdAsync(seasonTvdbId ?? 0, string.Empty, cancellationToken)
+                .ConfigureAwait(false);
+            return seasonInfo.Artwork;
         }
-
-        /// <inheritdoc />
-        public Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)
+        catch (Exception ex) when (
+            (ex is SeriesException seriesEx && seriesEx.InnerException is JsonException)
+            || (ex is SeasonsException seasonEx && seasonEx.InnerException is JsonException))
         {
-            return _httpClientFactory.CreateClient(NamedClient.Default).GetAsync(new Uri(url), cancellationToken);
+            _logger.LogError(ex, "Failed to retrieve season images for series {TvDbId}", seriesTvdbId);
+            return Array.Empty<ArtworkBaseRecord>();
         }
+    }
+
+    /// <inheritdoc />
+    public Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)
+    {
+        return _httpClientFactory.CreateClient(NamedClient.Default).GetAsync(new Uri(url), cancellationToken);
     }
 }

--- a/Jellyfin.Plugin.Tvdb/TvdbSdkExtensions.cs
+++ b/Jellyfin.Plugin.Tvdb/TvdbSdkExtensions.cs
@@ -1,6 +1,12 @@
+using System;
+using System.Globalization;
 using System.Linq;
 
 using Jellyfin.Extensions;
+
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Providers;
 
 using Tvdb.Sdk;
 
@@ -21,7 +27,7 @@ public static class TvdbSdkExtensions
     {
         return translations?
             .NameTranslations?
-            .FirstOrDefault(translation => TvdbUtils.MatchLanguage(language, translation.Language))?
+            .FirstOrDefault(translation => IsMatch(translation, language))?
             .Name;
     }
 
@@ -35,7 +41,141 @@ public static class TvdbSdkExtensions
     {
         return translations?
             .OverviewTranslations?
-            .FirstOrDefault(translation => TvdbUtils.MatchLanguage(language, translation.Language))?
+            .FirstOrDefault(translation => IsMatch(translation, language))?
             .Overview;
+    }
+
+    private static bool IsMatch(this Translation translation, string? language)
+    {
+        if (string.IsNullOrWhiteSpace(language))
+        {
+            return false;
+        }
+
+        language = language?.ToLowerInvariant() switch
+        {
+            "zh-tw" => "zh", // Unique case for zh-TW
+            "pt-br" => "pt", // Unique case for pt-BR0
+            _ => language,
+        };
+
+        // try to find a match (ISO 639-2)
+        return TvdbCultureInfo.GetCultureInfo(language!)?
+            .ThreeLetterISOLanguageNames?
+            .Contains(translation.Language, StringComparer.OrdinalIgnoreCase)
+            ?? false;
+    }
+
+    /// <summary>
+    /// Normalize <see cref="Language"/> to jellyfin format.
+    /// </summary>
+    /// <remarks>TVDb uses 3 character language.</remarks>
+    /// <param name="language">The <see cref="Language"/>.</param>
+    /// <returns>Normalized language.</returns>
+    private static string? NormalizeToJellyfin(this Language? language)
+    {
+        return language?.Id?.ToLowerInvariant() switch
+        {
+            "zhtw" => "zh-TW", // Unique case for zhtw
+            "pt" => "pt-BR", // Unique case for pt
+            var tvdbLang when tvdbLang is { } => TvdbCultureInfo.GetCultureInfo(tvdbLang)?.TwoLetterISOLanguageName, // to (ISO 639-1)
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Get <see cref="ImageType"/> from <see cref="ArtworkType"/>.
+    /// </summary>
+    /// <param name="artworkType">A <see cref="ArtworkType"/>.</param>
+    /// <returns><see cref="ImageType"/> or <see langword="null"/> if type is unknown.</returns>0
+    public static ImageType? GetImageType(this ArtworkType? artworkType)
+    {
+        return artworkType?.Name?.ToLowerInvariant() switch
+        {
+            "poster" => ImageType.Primary,
+            "banner" => ImageType.Banner,
+            "background" => ImageType.Backdrop,
+            "clearlogo" => ImageType.Logo,
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Creates a <see cref="RemoteImageInfo"/> from an <see cref="EpisodeExtendedRecord"/>.
+    /// </summary>
+    /// <param name="episodeRecord">The <see cref="EpisodeExtendedRecord"/>.</param>
+    /// <param name="providerName">The provider name.</param>
+    /// <returns>A <see cref="RemoteImageInfo"/>, or null if <see cref="EpisodeExtendedRecord"/> does not contain image information.</returns>
+    public static RemoteImageInfo? CreateImageInfo(this EpisodeExtendedRecord episodeRecord, string providerName)
+    {
+        if (string.IsNullOrEmpty(episodeRecord.Image))
+        {
+            return null;
+        }
+
+        return new RemoteImageInfo
+        {
+            ProviderName = providerName,
+            Url = episodeRecord.Image,
+            Type = ImageType.Primary
+        };
+    }
+
+    /// <summary>
+    /// Creates a <see cref="RemoteImageInfo"/> from an <see cref="ArtworkExtendedRecord"/>.
+    /// </summary>
+    /// <param name="artworkRecord">The <see cref="ArtworkExtendedRecord"/>.</param>
+    /// <param name="providerName">The provider name.</param>
+    /// <param name="type">The <see cref="ImageType"/>.</param>
+    /// <param name="language">The <see cref="Language"/>.</param>
+    /// <returns>A <see cref="RemoteImageInfo"/>, or null if <see cref="ImageType"/> is <see langword="null"/>.</returns>
+    public static RemoteImageInfo? CreateImageInfo(this ArtworkExtendedRecord artworkRecord, string providerName, ImageType? type, Language? language)
+    {
+        return CreateRemoteImageInfo(
+            artworkRecord.Image,
+            artworkRecord.Thumbnail,
+            (artworkRecord.Width, artworkRecord.Height),
+            providerName,
+            type,
+            language);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="RemoteImageInfo"/> from an <see cref="ArtworkExtendedRecord"/>.
+    /// </summary>
+    /// <param name="artworkRecord">The <see cref="ArtworkExtendedRecord"/>.</param>
+    /// <param name="providerName">The provider name.</param>
+    /// <param name="type">The <see cref="ImageType"/>.</param>
+    /// <param name="language">The <see cref="Language"/>.</param>
+    /// <returns>A <see cref="RemoteImageInfo"/>, or null if <see cref="ImageType"/> is <see langword="null"/>.</returns>
+    public static RemoteImageInfo? CreateImageInfo(this ArtworkBaseRecord artworkRecord, string providerName, ImageType? type, Language? language)
+    {
+        return CreateRemoteImageInfo(
+            artworkRecord.Image,
+            artworkRecord.Thumbnail,
+            (artworkRecord.Width, artworkRecord.Height),
+            providerName,
+            type,
+            language);
+    }
+
+    private static RemoteImageInfo? CreateRemoteImageInfo(string imageUrl, string thumbnailUrl, (long Width, long Height) imageDimension, string providerName, ImageType? type, Language? language)
+    {
+        if (type is null)
+        {
+            return null;
+        }
+
+        return new RemoteImageInfo
+        {
+            RatingType = RatingType.Score,
+            Url = imageUrl,
+            Width = Convert.ToInt32(imageDimension.Width, CultureInfo.InvariantCulture),
+            Height = Convert.ToInt32(imageDimension.Height, CultureInfo.InvariantCulture),
+            Type = type.Value,
+            Language = language.NormalizeToJellyfin()?.ToLowerInvariant(),
+            ProviderName = providerName,
+            ThumbnailUrl = thumbnailUrl
+        };
     }
 }

--- a/Jellyfin.Plugin.Tvdb/TvdbUtils.cs
+++ b/Jellyfin.Plugin.Tvdb/TvdbUtils.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
-using MediaBrowser.Model.Entities;
 using Tvdb.Sdk;
 
 namespace Jellyfin.Plugin.Tvdb
@@ -16,86 +14,6 @@ namespace Jellyfin.Plugin.Tvdb
         /// Base url for all requests.
         /// </summary>
         public const string TvdbBaseUrl = "https://www.thetvdb.com/";
-
-        /// <summary>
-        /// Get image type from key type.
-        /// </summary>
-        /// <param name="keyType">Key type.</param>
-        /// <returns>Image type.</returns>
-        /// <exception cref="ArgumentException">Unknown key type.</exception>
-        public static ImageType GetImageTypeFromKeyType(string? keyType)
-        {
-            if (!string.IsNullOrEmpty(keyType))
-            {
-                switch (keyType.ToLowerInvariant())
-                {
-                    case "poster": return ImageType.Primary;
-                    case "banner": return ImageType.Banner;
-                    case "background": return ImageType.Backdrop;
-                    case "clearlogo": return ImageType.Logo;
-                    default: throw new ArgumentException($"Invalid or unknown keytype: {keyType}", nameof(keyType));
-                }
-            }
-
-            throw new ArgumentException("Null keytype");
-        }
-
-        /// <summary>
-        /// Try to find a match for input language.
-        /// </summary>
-        /// <param name="language">input Language.</param>
-        /// <param name="tvdbLanguage">TVDB data language.</param>
-        /// <returns>Normalized language.</returns>
-        public static bool MatchLanguage(string? language, string tvdbLanguage)
-        {
-            if (string.IsNullOrWhiteSpace(language))
-            {
-                return false;
-            }
-
-            // Unique case for zh-TW
-            if (string.Equals(language, "zh-TW", StringComparison.OrdinalIgnoreCase))
-            {
-                language = "zhtw";
-            }
-
-            // Unique case for pt-BR
-            if (string.Equals(language, "pt-br", StringComparison.OrdinalIgnoreCase))
-            {
-                language = "pt";
-            }
-
-            // try to find a match (ISO 639-2)
-            return TvdbCultureInfo.GetCultureInfo(language)?.ThreeLetterISOLanguageNames?.Contains(tvdbLanguage, StringComparer.OrdinalIgnoreCase) ?? false;
-        }
-
-        /// <summary>
-        /// Normalize language to jellyfin format.
-        /// </summary>
-        /// <param name="language">Language.</param>
-        /// <returns>Normalized language.</returns>
-        public static string? NormalizeLanguageToJellyfin(string? language)
-        {
-            if (string.IsNullOrWhiteSpace(language))
-            {
-                return null;
-            }
-
-            // Unique case for zhtw
-            if (string.Equals(language, "zhtw", StringComparison.OrdinalIgnoreCase))
-            {
-                return "zh-TW";
-            }
-
-            // Unique case for pt
-            if (string.Equals(language, "pt", StringComparison.OrdinalIgnoreCase))
-            {
-                return "pt-BR";
-            }
-
-            // to (ISO 639-1)
-            return TvdbCultureInfo.GetCultureInfo(language)?.TwoLetterISOLanguageName;
-        }
 
         /// <summary>
         /// Converts SeriesAirsDays to DayOfWeek array.


### PR DESCRIPTION
Make the Client calls more resilient and robust by catching in some situations a serialization `JsonException` and return and empty or `null` value, instead of ignoring the exception.

See also #111  

I also made a cleanup of `TvdbSeasonImageProvider` and `TvdbSeriesImageProvider`, which shared some common code.  Will do here further steps in a different PR.