### PR TITLE
Remove required from the input for API key

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Configuration/config.html
+++ b/Jellyfin.Plugin.Tvdb/Configuration/config.html
@@ -18,7 +18,7 @@
                         <label for="txtTvdbApiKey">TheTvdb API Key:</label>
                         <input type="text" id="txtTvdbApiKey" is="emby-input" />
                         <div class="fieldDescription">
-                            TheTVDB Api Key from Subscriptions.
+                            Optional. TheTVDB Api Key from Subscriptions.
                         </div>
                     </div>
                     <div class="inputContainer">

--- a/Jellyfin.Plugin.Tvdb/Configuration/config.html
+++ b/Jellyfin.Plugin.Tvdb/Configuration/config.html
@@ -16,7 +16,7 @@
                     </div>
                     <div class="inputContainer">
                         <label for="txtTvdbApiKey">TheTvdb API Key:</label>
-                        <input type="text" id="txtTvdbApiKey" required="required" is="emby-input" />
+                        <input type="text" id="txtTvdbApiKey" is="emby-input" />
                         <div class="fieldDescription">
                             TheTVDB Api Key from Subscriptions.
                         </div>


### PR DESCRIPTION
Apparently plugin does not require a subscription pin, so remove the requirement for the pin to be set.

@crobibero Should we  also allow user to set their own API key and subscription pin?