### PR TITLE
Prevent images with no language tag to have same priority as matched language

### DIFF
--- a/Jellyfin.Plugin.Tvdb/CollectionExtensions.cs
+++ b/Jellyfin.Plugin.Tvdb/CollectionExtensions.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections;
+using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using MediaBrowser.Model.Providers;
 
 namespace Jellyfin.Plugin.Tvdb;
 
@@ -20,5 +23,40 @@ internal static class CollectionExtensions
         }
 
         return collection;
+    }
+
+    internal static IEnumerable<RemoteImageInfo> OrderByLanguageDescending(this IEnumerable<RemoteImageInfo> remoteImageInfos, string requestedLanguage)
+    {
+        if (string.IsNullOrWhiteSpace(requestedLanguage))
+        {
+            // Default to English if no requested language is specified.
+            requestedLanguage = "en";
+        }
+
+        var isRequestedLanguageEn = string.Equals(requestedLanguage, "en", StringComparison.OrdinalIgnoreCase);
+
+        return remoteImageInfos.OrderByDescending(i =>
+        {
+            if (string.Equals(requestedLanguage, i.Language, StringComparison.OrdinalIgnoreCase))
+            {
+                return 3;
+            }
+
+            if (string.IsNullOrEmpty(i.Language))
+            {
+                // Empty image language is image without any text
+                return 2;
+            }
+
+            if (!isRequestedLanguageEn && string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase))
+            {
+                // Prioritize English over non-requested languages.
+                return 1;
+            }
+
+            return 0;
+        })
+            .ThenByDescending(i => i.CommunityRating ?? 0)
+            .ThenByDescending(i => i.VoteCount ?? 0);
     }
 }

--- a/Jellyfin.Plugin.Tvdb/CollectionExtensions.cs
+++ b/Jellyfin.Plugin.Tvdb/CollectionExtensions.cs
@@ -42,19 +42,19 @@ internal static class CollectionExtensions
                 return 3;
             }
 
-            if (string.IsNullOrEmpty(i.Language))
-            {
-                // Empty image language is image without any text
-                return 2;
-            }
-
             if (!isRequestedLanguageEn && string.Equals(i.Language, "en", StringComparison.OrdinalIgnoreCase))
             {
                 // Prioritize English over non-requested languages.
-                return 1;
+                return 2;
             }
 
-            return 0;
+            if (string.IsNullOrEmpty(i.Language))
+            {
+                // Empty image language is image without any text. Set it to the lowest priority.
+                return 0;
+            }
+
+            return 1;
         });
     }
 }

--- a/Jellyfin.Plugin.Tvdb/CollectionExtensions.cs
+++ b/Jellyfin.Plugin.Tvdb/CollectionExtensions.cs
@@ -55,8 +55,6 @@ internal static class CollectionExtensions
             }
 
             return 0;
-        })
-            .ThenByDescending(i => i.CommunityRating ?? 0)
-            .ThenByDescending(i => i.VoteCount ?? 0);
+        });
     }
 }


### PR DESCRIPTION
Prevent images with no language tag to have same priority as matched language. So images with matched language will come first than images with no language tag. Images with no language tag are images without any text.