### PR TITLE
Some unstable fixes

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbMissingEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbMissingEpisodeProvider.cs
@@ -95,7 +95,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
             }
 
             var libraryOptions = _libraryManager.GetLibraryOptions(series);
-            var typeOptions = libraryOptions.GetTypeOptions(item.GetType().Name);
+            var typeOptions = libraryOptions.GetTypeOptions(series.GetType().Name);
             return _baseItemManager.IsMetadataFetcherEnabled(series, typeOptions, ProviderName);
         }
 

--- a/Jellyfin.Plugin.Tvdb/TvdbClientManager.cs
+++ b/Jellyfin.Plugin.Tvdb/TvdbClientManager.cs
@@ -553,7 +553,7 @@ public class TvdbClientManager : IDisposable
     {
         if (_memoryCache is MemoryCache memoryCache)
         {
-            memoryCache.Compact(1);
+            memoryCache.Clear();
             return true;
         }
         else

--- a/Jellyfin.Plugin.Tvdb/TvdbPluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Tvdb/TvdbPluginServiceRegistrator.cs
@@ -1,3 +1,4 @@
+using Jellyfin.Plugin.Tvdb.Providers;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Plugins;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +14,7 @@ namespace Jellyfin.Plugin.Tvdb
         public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
         {
             serviceCollection.AddSingleton<TvdbClientManager>();
+            serviceCollection.AddHostedService<TvdbMissingEpisodeProvider>();
         }
     }
 }


### PR DESCRIPTION
- Register TvdbMissingEpisodeProvider
- GetTypeOptions from series instead of item so actions against missing episodes will run.
- use clear instead of compat to clear cache.

Tested on my patched plugin for 10.9.0.
Requires:
  ```
  <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
```
plus updated jellyfin libs to compile successfully.