### PR TITLE
Fix: Gets all updates after hitting the 500 entry per page limit

### DIFF
--- a/Jellyfin.Plugin.Tvdb/ScheduledTasks/UpdateTask.cs
+++ b/Jellyfin.Plugin.Tvdb/ScheduledTasks/UpdateTask.cs
@@ -104,8 +104,8 @@ namespace Jellyfin.Plugin.Tvdb.ScheduledTasks
         private async Task<List<BaseItem>> GetItemsUpdated(CancellationToken cancellationToken)
         {
             double fromTime = DateTimeOffset.UtcNow.AddHours(MetadataUpdateInHours).ToUnixTimeSeconds();
-            IReadOnlyList<EntityUpdate> episodeUpdates = (await _tvdbClientManager.GetUpdates(fromTime, cancellationToken, Type.Episodes, Action.Update).ConfigureAwait(false)).ToList();
-            IReadOnlyList<EntityUpdate> seriesUpdates = (await _tvdbClientManager.GetUpdates(fromTime, cancellationToken, Type.Series, Action.Update).ConfigureAwait(false)).ToList();
+            IReadOnlyList<EntityUpdate> episodeUpdates = await _tvdbClientManager.GetUpdates(fromTime, cancellationToken, Type.Episodes, Action.Update).ConfigureAwait(false);
+            IReadOnlyList<EntityUpdate> seriesUpdates = await _tvdbClientManager.GetUpdates(fromTime, cancellationToken, Type.Series, Action.Update).ConfigureAwait(false);
 
             var allUpdates = episodeUpdates.Concat(seriesUpdates);
 

--- a/Jellyfin.Plugin.Tvdb/ScheduledTasks/UpdateTask.cs
+++ b/Jellyfin.Plugin.Tvdb/ScheduledTasks/UpdateTask.cs
@@ -104,8 +104,8 @@ namespace Jellyfin.Plugin.Tvdb.ScheduledTasks
         private async Task<List<BaseItem>> GetItemsUpdated(CancellationToken cancellationToken)
         {
             double fromTime = DateTimeOffset.UtcNow.AddHours(MetadataUpdateInHours).ToUnixTimeSeconds();
-            IEnumerable<EntityUpdate> episodeUpdates = await _tvdbClientManager.GetUpdates(fromTime, cancellationToken, Type.Episodes, Action.Update).ConfigureAwait(false);
-            IEnumerable<EntityUpdate> seriesUpdates = await _tvdbClientManager.GetUpdates(fromTime, cancellationToken, Type.Series, Action.Update).ConfigureAwait(false);
+            IReadOnlyList<EntityUpdate> episodeUpdates = (await _tvdbClientManager.GetUpdates(fromTime, cancellationToken, Type.Episodes, Action.Update).ConfigureAwait(false)).ToList();
+            IReadOnlyList<EntityUpdate> seriesUpdates = (await _tvdbClientManager.GetUpdates(fromTime, cancellationToken, Type.Series, Action.Update).ConfigureAwait(false)).ToList();
 
             var allUpdates = episodeUpdates.Concat(seriesUpdates);
 

--- a/Jellyfin.Plugin.Tvdb/ScheduledTasks/UpdateTask.cs
+++ b/Jellyfin.Plugin.Tvdb/ScheduledTasks/UpdateTask.cs
@@ -72,7 +72,8 @@ namespace Jellyfin.Plugin.Tvdb.ScheduledTasks
             progress.Report(10);
             MetadataRefreshOptions refreshOptions = new MetadataRefreshOptions(new DirectoryService(_fileSystem))
             {
-                MetadataRefreshMode = MetadataRefreshMode.FullRefresh
+                MetadataRefreshMode = MetadataRefreshMode.FullRefresh,
+                ReplaceAllMetadata = true,
             };
             double increment = 90.0 / toUpdateItems.Count;
             double currentProgress = 10;

--- a/Jellyfin.Plugin.Tvdb/ScheduledTasks/UpdateTask.cs
+++ b/Jellyfin.Plugin.Tvdb/ScheduledTasks/UpdateTask.cs
@@ -103,8 +103,8 @@ namespace Jellyfin.Plugin.Tvdb.ScheduledTasks
         private async Task<List<BaseItem>> GetItemsUpdated(CancellationToken cancellationToken)
         {
             double fromTime = DateTimeOffset.UtcNow.AddHours(MetadataUpdateInHours).ToUnixTimeSeconds();
-            IReadOnlyList<EntityUpdate> episodeUpdates = await _tvdbClientManager.GetUpdates(fromTime, cancellationToken, Type.Episodes, Action.Update).ConfigureAwait(false);
-            IReadOnlyList<EntityUpdate> seriesUpdates = await _tvdbClientManager.GetUpdates(fromTime, cancellationToken, Type.Series, Action.Update).ConfigureAwait(false);
+            IEnumerable<EntityUpdate> episodeUpdates = await _tvdbClientManager.GetUpdates(fromTime, cancellationToken, Type.Episodes, Action.Update).ConfigureAwait(false);
+            IEnumerable<EntityUpdate> seriesUpdates = await _tvdbClientManager.GetUpdates(fromTime, cancellationToken, Type.Series, Action.Update).ConfigureAwait(false);
 
             var allUpdates = episodeUpdates.Concat(seriesUpdates);
 

--- a/Jellyfin.Plugin.Tvdb/TvdbClientManager.cs
+++ b/Jellyfin.Plugin.Tvdb/TvdbClientManager.cs
@@ -542,18 +542,18 @@ public class TvdbClientManager : IDisposable
         var updatesClient = _serviceProvider.GetRequiredService<IUpdatesClient>();
         await LoginAsync().ConfigureAwait(false);
         var updatesResult = await updatesClient.UpdatesAsync(since: fromTime, type: type, action: action, cancellationToken: cancellationToken).ConfigureAwait(false);
-        IEnumerable<EntityUpdate> updates = updatesResult.Data;
+        var updates = updatesResult.Data.ToList();
 
         // Each page has limit of 500 updates. Get all updates starting from page 1. First page (page 0) is already fetched.
         int page = 1;
         while (updatesResult.Links.Next != null)
         {
             updatesResult = await updatesClient.UpdatesAsync(since: fromTime, type: type, action: action, page: page, cancellationToken: cancellationToken).ConfigureAwait(false);
-            updates = updates.Concat(updatesResult.Data);
+            updates.AddRange(updatesResult.Data);
             page++;
         }
 
-        return updates.ToList();
+        return updates;
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Tvdb/TvdbClientManager.cs
+++ b/Jellyfin.Plugin.Tvdb/TvdbClientManager.cs
@@ -533,7 +533,7 @@ public class TvdbClientManager : IDisposable
     /// <param name="type"> Type of data.</param>
     /// <param name="action">Delete, update or null.</param>
     /// <returns>A list of updates.</returns>
-    public async Task<IEnumerable<EntityUpdate>> GetUpdates(
+    public async Task<IReadOnlyList<EntityUpdate>> GetUpdates(
         double fromTime,
         CancellationToken cancellationToken,
         Type? type = null,
@@ -553,7 +553,7 @@ public class TvdbClientManager : IDisposable
             page++;
         }
 
-        return updates;
+        return updates.ToList();
     }
 
     /// <summary>


### PR DESCRIPTION
Also fixes metadata not updating after refresh in 10.9.0 (was dependant on a bugged behaviour that was fixed in the server repo)