### PR TITLE
Add support for regional, alternate, altdvd orders (Alt implementation)

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Configuration/more-display-order-options.js
+++ b/Jellyfin.Plugin.Tvdb/Configuration/more-display-order-options.js
@@ -1,0 +1,51 @@
+/**Setup Event Listeners */
+document.addEventListener('viewshow', viewShowEvent)
+
+// Mutation Observer
+const observer = new MutationObserver(injectDisplayOrderOptions);
+// Only observe when on tv.html, details, home.html, or search.html
+observer.disconnect();
+
+function viewShowEvent(){
+    const location = window.location.hash;
+    console.debug("Current: " + location);
+    if (location.startsWith('#/tv.html') || location.startsWith('#/details') || location.startsWith('#/home.html') || location.startsWith('#/search.html')){
+        console.debug('Connecting Observer');
+        observer.observe(document.body, {childList: true, subtree: true});
+    }
+    else{
+        console.debug('Disconnecting Observer');
+        observer.disconnect();
+    }
+}
+
+function injectDisplayOrderOptions(MutationList, observer){
+    console.debug("Mutation Observer Triggered");
+    const selectDisplayOrder = document.getElementById('selectDisplayOrder');
+
+    if (!selectDisplayOrder){
+        console.debug('selectDisplayOrder not found');
+        return;
+    }
+    console.debug('selectDisplayOrder found');
+    console.debug('Injecting Options')
+    observer.disconnect();
+    const options = [
+        {value: 'alternate', text: 'Alternate'},
+        {value: 'regional', text: 'Regional'},
+        {value: 'altdvd', text: 'Alternate DVD'}
+    ]
+    //check if options already exist
+    if (selectDisplayOrder.options.length > 8){
+        console.debug('Options already exist');
+        observer.observe(document.body, {childList: true, subtree: true});
+        return;
+    }
+    options.forEach(option => {
+        const optionElement = document.createElement('option');
+        optionElement.value = option.value;
+        optionElement.text = option.text;
+        selectDisplayOrder.appendChild(optionElement);
+    });
+    observer.observe(document.body, {childList: true, subtree: true});
+}

--- a/Jellyfin.Plugin.Tvdb/Jellyfin.Plugin.Tvdb.csproj
+++ b/Jellyfin.Plugin.Tvdb/Jellyfin.Plugin.Tvdb.csproj
@@ -12,7 +12,9 @@
 
   <ItemGroup>
     <None Remove="Configuration\config.html" />
+    <None Remove="Configuration\more-display-order-options.js" />
     <EmbeddedResource Include="Configuration\config.html" />
+    <EmbeddedResource Include="Configuration\more-display-order-options.js" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.Tvdb/TvdbClientManager.cs
+++ b/Jellyfin.Plugin.Tvdb/TvdbClientManager.cs
@@ -450,6 +450,9 @@ public class TvdbClientManager : IDisposable
         {
             switch (searchInfo.SeriesDisplayOrder)
             {
+                case "regional":
+                case "alternate":
+                case "altdvd":
                 case "dvd":
                     episodeNumber = searchInfo.IndexNumber.Value;
                     seasonNumber = searchInfo.ParentIndexNumber.Value;
@@ -493,6 +496,9 @@ public class TvdbClientManager : IDisposable
         {
             switch (searchInfo.SeriesDisplayOrder)
             {
+                case "regional":
+                case "alternate":
+                case "altdvd":
                 case "dvd":
                 case "absolute":
                     seriesResponse = await seriesClient.GetSeriesEpisodesAsync(page: 0, id: seriesTvdbId, season_type: searchInfo.SeriesDisplayOrder, season: seasonNumber, episodeNumber: episodeNumber, airDate: airDate, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/Jellyfin.Plugin.Tvdb/TvdbPlugin.cs
+++ b/Jellyfin.Plugin.Tvdb/TvdbPlugin.cs
@@ -16,6 +16,8 @@ namespace Jellyfin.Plugin.Tvdb
     /// </summary>
     public class TvdbPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     {
+        private readonly ILogger<TvdbPlugin> _logger;
+
         /// <summary>
         /// Gets the provider name.
         /// </summary>
@@ -26,13 +28,12 @@ namespace Jellyfin.Plugin.Tvdb
         /// </summary>
         public const string ProviderId = "Tvdb";
 
-        private readonly ILogger<TvdbPlugin> _logger;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TvdbPlugin"/> class.
         /// </summary>
         /// <param name="applicationPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
         /// <param name="xmlSerializer">Instance of the <see cref="IXmlSerializer"/> interface.</param>
+        /// <param name="logger">Instance of the <see cref="ILogger{TvdbPlugin}"/> interface.</param>
         public TvdbPlugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, ILogger<TvdbPlugin> logger)
             : base(applicationPaths, xmlSerializer)
         {


### PR DESCRIPTION
Instead of depending on jellyfin-web to have the option, inject the options instead.

Fixes: https://github.com/jellyfin/jellyfin-plugin-tvdb/issues/49