### PR TITLE
Fix retrieval of episode num for virtual episode.

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using ICU4N.Text;
 using Jellyfin.Data.Enums;
 using Jellyfin.Extensions;
 using MediaBrowser.Common.Net;


### PR DESCRIPTION
Virtual Episodes loses episode number data when doing a full refresh. Current implementation does not work due to wrong properties being used to compare. EpisodeExtendedRecord does not provide all the episode numbers for various display orders. So have to get all episodes for the series and search for the episode.