### PR TITLE
Display order change fix, Cache collision fix, restrict airsbefore/after to aired display order

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
@@ -168,7 +168,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
             var episodeTvdbId = searchInfo.GetTvdbId().ToString(CultureInfo.InvariantCulture);
             try
             {
-                if (string.Equals(episodeTvdbId, "0", StringComparison.OrdinalIgnoreCase) || ignoreTvdbIdField)
+                if (string.Equals(episodeTvdbId, "0", StringComparison.OrdinalIgnoreCase) || ignoreTvdbIdField || searchInfo.IsAutomated)
                 {
                     episodeTvdbId = await _tvdbClientManager
                         .GetEpisodeTvdbId(searchInfo, searchInfo.MetadataLanguage, cancellationToken)

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
@@ -215,9 +215,6 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                     IndexNumber = id.IndexNumber,
                     ParentIndexNumber = id.ParentIndexNumber,
                     IndexNumberEnd = id.IndexNumberEnd,
-                    AirsBeforeEpisodeNumber = episode.AirsBeforeEpisode,
-                    AirsAfterSeasonNumber = episode.AirsAfterSeason,
-                    AirsBeforeSeasonNumber = episode.AirsBeforeSeason,
                     // Tvdb uses 3 letter code for language (prob ISO 639-2)
                     // Reverts to OriginalName if no translation is found
                     Name = episode.Translations.GetTranslatedNamedOrDefault(id.MetadataLanguage) ?? episode.Name,
@@ -231,6 +228,14 @@ namespace Jellyfin.Plugin.Tvdb.Providers
             item.SetTvdbId(episode.Id);
             var imdbID = episode.RemoteIds.FirstOrDefault(x => string.Equals(x.SourceName, "IMDB", StringComparison.OrdinalIgnoreCase))?.Id;
             item.SetProviderIdIfHasValue(MetadataProvider.Imdb, imdbID);
+
+            // Below metadata info only applicable for Aired Order
+            if (string.IsNullOrEmpty(id.SeriesDisplayOrder))
+            {
+                item.AirsBeforeEpisodeNumber = episode.AirsBeforeEpisode;
+                item.AirsAfterSeasonNumber = episode.AirsAfterSeason;
+                item.AirsBeforeSeasonNumber = episode.AirsBeforeSeason;
+            }
 
             // Missing episodes loses the episode number when refreshed.
             if (id.IsMissingEpisode)

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbMissingEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbMissingEpisodeProvider.cs
@@ -449,15 +449,21 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                 IsVirtualItem = true,
                 SeasonId = season.Id,
                 SeriesId = season.Series.Id,
-                AirsBeforeEpisodeNumber = episode.AirsBeforeEpisode,
-                AirsAfterSeasonNumber = episode.AirsAfterSeason,
-                AirsBeforeSeasonNumber = episode.AirsBeforeSeason,
                 Overview = episode.Overview,
                 SeriesName = season.Series.Name,
                 SeriesPresentationUniqueKey = season.SeriesPresentationUniqueKey,
                 SeasonName = season.Name,
                 DateLastSaved = DateTime.UtcNow
             };
+
+            // Below metadata info only applicable for Aired Order
+            if (string.IsNullOrEmpty(season.Series.DisplayOrder))
+            {
+                newEpisode.AirsBeforeEpisodeNumber = episode.AirsBeforeEpisode;
+                newEpisode.AirsAfterSeasonNumber = episode.AirsAfterSeason;
+                newEpisode.AirsBeforeSeasonNumber = episode.AirsBeforeSeason;
+            }
+
             if (DateTime.TryParse(episode!.Aired, out var premiereDate))
             {
                 newEpisode.PremiereDate = premiereDate;

--- a/Jellyfin.Plugin.Tvdb/ScheduledTasks/UpdateTask.cs
+++ b/Jellyfin.Plugin.Tvdb/ScheduledTasks/UpdateTask.cs
@@ -74,6 +74,7 @@ namespace Jellyfin.Plugin.Tvdb.ScheduledTasks
             {
                 MetadataRefreshMode = MetadataRefreshMode.FullRefresh,
                 ReplaceAllMetadata = true,
+                IsAutomated = false,
             };
             double increment = 90.0 / toUpdateItems.Count;
             double currentProgress = 10;

--- a/Jellyfin.Plugin.Tvdb/TvdbClientManager.cs
+++ b/Jellyfin.Plugin.Tvdb/TvdbClientManager.cs
@@ -477,7 +477,7 @@ public class TvdbClientManager : IDisposable
                     break;
             }
 
-            key = $"FindTvdbEpisodeId_{seriesTvdbIdString}_{seasonNumber.Value.ToString(CultureInfo.InvariantCulture)}_{episodeNumber.Value.ToString(CultureInfo.InvariantCulture)}";
+            key = $"FindTvdbEpisodeId_{seriesTvdbIdString}_{seasonNumber.Value.ToString(CultureInfo.InvariantCulture)}_{episodeNumber.Value.ToString(CultureInfo.InvariantCulture)}_{searchInfo.SeriesDisplayOrder}";
         }
         else if (searchInfo.PremiereDate.HasValue)
         {


### PR DESCRIPTION
Fix the cache key to account for different types of display order. Important fix so ppl can use identify with diff display ordering.

Restrict the AirsBeforeEpisodeNumber, AirsAfterSeasonNumber and AirsBeforeSeasonNumber to only aired order display order