### PR TITLE
Get season id according to selected display order.

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbSeasonImageProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbSeasonImageProvider.cs
@@ -88,8 +88,14 @@ public class TvdbSeasonImageProvider : IRemoteImageProvider
 
         var seriesTvdbId = series.GetTvdbId();
         var seasonNumber = season.IndexNumber.Value;
+        var displayOrder = season.Series.DisplayOrder;
 
-        var seasonArtworks = await GetSeasonArtworks(seriesTvdbId, seasonNumber, cancellationToken)
+        if (string.IsNullOrEmpty(displayOrder))
+        {
+            displayOrder = "official";
+        }
+
+        var seasonArtworks = await GetSeasonArtworks(seriesTvdbId, seasonNumber, displayOrder, cancellationToken)
             .ConfigureAwait(false);
 
         var remoteImages = new List<RemoteImageInfo>();
@@ -106,13 +112,13 @@ public class TvdbSeasonImageProvider : IRemoteImageProvider
         return remoteImages.OrderByLanguageDescending(item.GetPreferredMetadataLanguage());
     }
 
-    private async Task<IReadOnlyList<ArtworkBaseRecord>> GetSeasonArtworks(int seriesTvdbId, int seasonNumber, CancellationToken cancellationToken)
+    private async Task<IReadOnlyList<ArtworkBaseRecord>> GetSeasonArtworks(int seriesTvdbId, int seasonNumber, string displayOrder, CancellationToken cancellationToken)
     {
         try
         {
             var seriesInfo = await _tvdbClientManager.GetSeriesExtendedByIdAsync(seriesTvdbId, string.Empty, cancellationToken, small: true)
                 .ConfigureAwait(false);
-            var seasonTvdbId = seriesInfo.Seasons.FirstOrDefault(s => s.Number == seasonNumber)?.Id;
+            var seasonTvdbId = seriesInfo.Seasons.FirstOrDefault(s => s.Number == seasonNumber && s.Type.Type == displayOrder)?.Id;
 
             var seasonInfo = await _tvdbClientManager.GetSeasonByIdAsync(seasonTvdbId ?? 0, string.Empty, cancellationToken)
                 .ConfigureAwait(false);


### PR DESCRIPTION
Currently, it will use the first season id that matches with the season number (usually aired order). However, seasons will have different id based on its display order. Season images are grouped according to that display order. So, to get the correct images for the display order, correct season id for the display order should be retrieved. In the case of no images can be found for that display order, fallback to aired order images.