### PR TITLE
Use official instead of default

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
@@ -247,7 +247,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                     var displayOrder = id.SeriesDisplayOrder;
                     if (string.IsNullOrEmpty(displayOrder))
                     {
-                        displayOrder = "default";
+                        displayOrder = "official";
                     }
 
                     // EpisodeExtendedRecord does not provide all the episode numbers for various display orders. So have to get all episodes for the series and search for the episode.

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbMissingEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbMissingEpisodeProvider.cs
@@ -343,10 +343,10 @@ namespace Jellyfin.Plugin.Tvdb.Providers
         {
             try
             {
-                // If displayOrder is not set, use default
+                // If displayOrder is not set, use aired order
                 if (string.IsNullOrEmpty(displayOrder))
                 {
-                    displayOrder = "default";
+                    displayOrder = "official";
                 }
 
                 // Fetch all episodes for the series

--- a/Jellyfin.Plugin.Tvdb/TvdbClientManager.cs
+++ b/Jellyfin.Plugin.Tvdb/TvdbClientManager.cs
@@ -504,13 +504,13 @@ public class TvdbClientManager : IDisposable
                     seriesResponse = await seriesClient.GetSeriesEpisodesAsync(page: 0, id: seriesTvdbId, season_type: searchInfo.SeriesDisplayOrder, season: seasonNumber, episodeNumber: episodeNumber, airDate: airDate, cancellationToken: cancellationToken).ConfigureAwait(false);
                     break;
                 default:
-                    seriesResponse = await seriesClient.GetSeriesEpisodesAsync(page: 0, id: seriesTvdbId, season_type: "default", season: seasonNumber, episodeNumber: episodeNumber, airDate: airDate, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    seriesResponse = await seriesClient.GetSeriesEpisodesAsync(page: 0, id: seriesTvdbId, season_type: "official", season: seasonNumber, episodeNumber: episodeNumber, airDate: airDate, cancellationToken: cancellationToken).ConfigureAwait(false);
                     break;
             }
         }
-        else // when special use default order
+        else // when special use aired order
         {
-            seriesResponse = await seriesClient.GetSeriesEpisodesAsync(page: 0, id: seriesTvdbId, season_type: "default", season: seasonNumber, episodeNumber: episodeNumber, airDate: airDate, cancellationToken: cancellationToken).ConfigureAwait(false);
+            seriesResponse = await seriesClient.GetSeriesEpisodesAsync(page: 0, id: seriesTvdbId, season_type: "official", season: seasonNumber, episodeNumber: episodeNumber, airDate: airDate, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         Data2 seriesData = seriesResponse.Data;


### PR DESCRIPTION
I haven't seen a series in Tvdb that does not use air order as default yet. :/

 Just in case, use official instead of default. In tvdb, official = aired order