### PR TITLE
Skip Characters with person name is null / Handle null RemoteIds

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
@@ -274,6 +274,12 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                 for (var i = 0; i < episode.Characters.Count; ++i)
                 {
                     var currentActor = episode.Characters[i];
+                    if (currentActor.PersonName is null)
+                    {
+                        // Skip people with no person name
+                        continue;
+                    }
+
                     if (string.Equals(currentActor.PeopleType, "Actor", StringComparison.OrdinalIgnoreCase))
                     {
                         result.AddPerson(new PersonInfo

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
@@ -274,7 +274,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                 for (var i = 0; i < episode.Characters.Count; ++i)
                 {
                     var currentActor = episode.Characters[i];
-                    if (currentActor.PersonName is null)
+                    if (string.IsNullOrEmpty(currentActor.PersonName))
                     {
                         // Skip people with no person name
                         continue;

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
@@ -226,7 +226,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
 
             var item = result.Item;
             item.SetTvdbId(episode.Id);
-            var imdbID = episode.RemoteIds.FirstOrDefault(x => string.Equals(x.SourceName, "IMDB", StringComparison.OrdinalIgnoreCase))?.Id;
+            var imdbID = episode.RemoteIds?.FirstOrDefault(x => string.Equals(x.SourceName, "IMDB", StringComparison.OrdinalIgnoreCase))?.Id;
             item.SetProviderIdIfHasValue(MetadataProvider.Imdb, imdbID);
 
             // Below metadata info only applicable for Aired Order

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbSeriesProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbSeriesProvider.cs
@@ -165,7 +165,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                 remoteResult.ProductionYear = date.Year;
             }
 
-            var imdbID = series.RemoteIds.FirstOrDefault(x => x.SourceName == "IMDB")?.Id;
+            var imdbID = series.RemoteIds?.FirstOrDefault(x => x.SourceName == "IMDB")?.Id;
             remoteResult.SetProviderIdIfHasValue(MetadataProvider.Imdb, imdbID);
             remoteResult.SetTvdbId(series.Id);
 
@@ -350,13 +350,13 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                         await _tvdbClientManager.GetSeriesExtendedByIdAsync(Convert.ToInt32(seriesSearchResult.Tvdb_id, CultureInfo.InvariantCulture), language, cancellationToken, small: true)
                             .ConfigureAwait(false);
 
-                    var imdbId = seriesResult.RemoteIds.FirstOrDefault(x => string.Equals(x.SourceName, "IMDB", StringComparison.OrdinalIgnoreCase))?.Id.ToString();
+                    var imdbId = seriesResult.RemoteIds?.FirstOrDefault(x => string.Equals(x.SourceName, "IMDB", StringComparison.OrdinalIgnoreCase))?.Id.ToString();
                     remoteSearchResult.SetProviderIdIfHasValue(MetadataProvider.Imdb, imdbId);
 
-                    var zap2ItId = seriesResult.RemoteIds.FirstOrDefault(x => string.Equals(x.SourceName, "Zap2It", StringComparison.OrdinalIgnoreCase))?.Id.ToString();
+                    var zap2ItId = seriesResult.RemoteIds?.FirstOrDefault(x => string.Equals(x.SourceName, "Zap2It", StringComparison.OrdinalIgnoreCase))?.Id.ToString();
                     remoteSearchResult.SetProviderIdIfHasValue(MetadataProvider.Zap2It, zap2ItId);
 
-                    var tmdbId = seriesResult.RemoteIds.FirstOrDefault(x => string.Equals(x.SourceName, "TheMovieDB.com", StringComparison.OrdinalIgnoreCase))?.Id.ToString();
+                    var tmdbId = seriesResult.RemoteIds?.FirstOrDefault(x => string.Equals(x.SourceName, "TheMovieDB.com", StringComparison.OrdinalIgnoreCase))?.Id.ToString();
 
                     // Sometimes, tvdb will return tmdbid as {tmdbid}-{title} like in the tmdb url. Grab the tmdbid only.
                     var tmdbIdLeft = StringExtensions.LeftPart(tmdbId, '-').ToString();
@@ -456,13 +456,13 @@ namespace Jellyfin.Plugin.Tvdb.Providers
             // Attempts to default to USA if not found
             series.OfficialRating = tvdbSeries.ContentRatings.FirstOrDefault(x => string.Equals(x.Country, TvdbCultureInfo.GetCountryInfo(info.MetadataCountryCode)?.ThreeLetterISORegionName, StringComparison.OrdinalIgnoreCase))?.Name ?? tvdbSeries.ContentRatings.FirstOrDefault(x => string.Equals(x.Country, "usa", StringComparison.OrdinalIgnoreCase))?.Name;
 
-            var imdbId = tvdbSeries.RemoteIds.FirstOrDefault(x => string.Equals(x.SourceName, "IMDB", StringComparison.OrdinalIgnoreCase))?.Id.ToString();
+            var imdbId = tvdbSeries.RemoteIds?.FirstOrDefault(x => string.Equals(x.SourceName, "IMDB", StringComparison.OrdinalIgnoreCase))?.Id.ToString();
             series.SetProviderIdIfHasValue(MetadataProvider.Imdb, imdbId);
 
-            var zap2ItId = tvdbSeries.RemoteIds.FirstOrDefault(x => string.Equals(x.SourceName, "Zap2It", StringComparison.OrdinalIgnoreCase))?.Id.ToString();
+            var zap2ItId = tvdbSeries.RemoteIds?.FirstOrDefault(x => string.Equals(x.SourceName, "Zap2It", StringComparison.OrdinalIgnoreCase))?.Id.ToString();
             series.SetProviderIdIfHasValue(MetadataProvider.Zap2It, zap2ItId);
 
-            var tmdbId = tvdbSeries.RemoteIds.FirstOrDefault(x => string.Equals(x.SourceName, "TheMovieDB.com", StringComparison.OrdinalIgnoreCase))?.Id.ToString();
+            var tmdbId = tvdbSeries.RemoteIds?.FirstOrDefault(x => string.Equals(x.SourceName, "TheMovieDB.com", StringComparison.OrdinalIgnoreCase))?.Id.ToString();
             series.SetProviderIdIfHasValue(MetadataProvider.Tmdb, tmdbId);
 
             if (Enum.TryParse(tvdbSeries.Status.Name, true, out SeriesStatus seriesStatus))


### PR DESCRIPTION
Sometimes, TheTVDB returns characters with PersonName set to be null. Skip if it is null.
RemoteIds can be null too.
Fixes: https://github.com/jellyfin/jellyfin-plugin-tvdb/issues/159