### PR TITLE
Add Tvdb Collection Ids

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Providers/ExternalId/TvdbCollectionsExternalId.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/ExternalId/TvdbCollectionsExternalId.cs
@@ -1,0 +1,30 @@
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Providers;
+
+namespace Jellyfin.Plugin.Tvdb.Providers.ExternalId
+{
+    /// <inheritdoc/>
+    public class TvdbCollectionsExternalId : IExternalId
+    {
+        /// <inheritdoc/>
+        public string ProviderName => TvdbPlugin.ProviderName;
+
+        /// <inheritdoc/>
+        public string Key => TvdbPlugin.CollectionProviderId;
+
+        /// <inheritdoc/>
+        public ExternalIdMediaType? Type => ExternalIdMediaType.BoxSet;
+
+        /// <inheritdoc/>
+        public string? UrlFormatString => null;
+
+        /// <inheritdoc/>
+        public bool Supports(IHasProviderIds item)
+        {
+            return item is Movie || item is Series;
+        }
+    }
+}

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbSeriesProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbSeriesProvider.cs
@@ -460,7 +460,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                 var collections = jsonElement.Deserialize<List<object>>();
                 if (collections is not null)
                 {
-                    string collectionIds = string.Empty;
+                    StringBuilder collectionIds = new StringBuilder();
                     foreach (var collection in collections)
                     {
                         if (collection is JsonElement jsonElementCollection)
@@ -469,12 +469,12 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                             if (isOfficial is true)
                             {
                                 var id = jsonElementCollection.GetProperty("id").GetInt32().ToString(CultureInfo.InvariantCulture);
-                                collectionIds += id + ";";
+                                collectionIds.Append(id).Append(';');
                             }
                         }
                     }
 
-                    series.SetProviderIdIfHasValue(TvdbPlugin.CollectionProviderId, collectionIds);
+                    series.SetProviderIdIfHasValue(TvdbPlugin.CollectionProviderId, collectionIds.ToString());
                 }
             }
 

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbSeriesProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbSeriesProvider.cs
@@ -460,19 +460,10 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                 var collections = jsonElement.Deserialize<List<object>>();
                 if (collections is not null)
                 {
-                    StringBuilder collectionIds = new StringBuilder();
-                    foreach (var collection in collections)
-                    {
-                        if (collection is JsonElement jsonElementCollection)
-                        {
-                            var isOfficial = jsonElementCollection.GetProperty("isOfficial").GetBoolean();
-                            if (isOfficial is true)
-                            {
-                                var id = jsonElementCollection.GetProperty("id").GetInt32().ToString(CultureInfo.InvariantCulture);
-                                collectionIds.Append(id).Append(';');
-                            }
-                        }
-                    }
+                    var collectionIds = collections.OfType<JsonElement>()
+                        .Where(x => x.GetProperty("isOfficial").GetBoolean())
+                        .Select(x => x.GetProperty("id").GetInt32().ToString(CultureInfo.InvariantCulture))
+                        .Aggregate(new StringBuilder(), (sb, id) => sb.Append(id).Append(';'));
 
                     series.SetProviderIdIfHasValue(TvdbPlugin.CollectionProviderId, collectionIds.ToString());
                 }

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbSeriesProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbSeriesProvider.cs
@@ -477,6 +477,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                     series.SetProviderIdIfHasValue(TvdbPlugin.CollectionProviderId, collectionIds);
                 }
             }
+
             var imdbId = tvdbSeries.RemoteIds?.FirstOrDefault(x => string.Equals(x.SourceName, "IMDB", StringComparison.OrdinalIgnoreCase))?.Id.ToString();
             series.SetProviderIdIfHasValue(MetadataProvider.Imdb, imdbId);
 

--- a/Jellyfin.Plugin.Tvdb/TvdbPlugin.cs
+++ b/Jellyfin.Plugin.Tvdb/TvdbPlugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.Tvdb.Configuration;
 using MediaBrowser.Common.Configuration;
@@ -22,6 +22,11 @@ namespace Jellyfin.Plugin.Tvdb
         /// Gets the provider id.
         /// </summary>
         public const string ProviderId = "Tvdb";
+
+        /// <summary>
+        /// Gets the collection provider id.
+        /// </summary>
+        public const string CollectionProviderId = "TvdbCollection";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TvdbPlugin"/> class.


### PR DESCRIPTION
A series can have multiple tvdb collection ids. So store them as a string and delimit them with semicolons.
For use for future tvdb collection management