### PR TITLE
Only generate url when there is externalId for season

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbExternalUrlProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbExternalUrlProvider.cs
@@ -46,7 +46,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                         displayOrder = "official";
                     }
 
-                    if (_supportedOrders.Contains(displayOrder) && !string.IsNullOrEmpty(seriesSlugId))
+                    if (_supportedOrders.Contains(displayOrder) && !string.IsNullOrEmpty(seriesSlugId) && !string.IsNullOrEmpty(externalId))
                     {
                         yield return TvdbUtils.TvdbBaseUrl + $"series/{seriesSlugId}/seasons/{displayOrder}/{item.IndexNumber}";
                     }


### PR DESCRIPTION
Season url is derived from the series slug and it will always generate the url as long as the series slug exist, even if the url is invalid. Only generate the url when there is season external id.

All other urls requires the external id or slug to be set for it to generate.