### PR TITLE
Fix update task

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Tvdb/Configuration/PluginConfiguration.cs
@@ -99,5 +99,10 @@ namespace Jellyfin.Plugin.Tvdb.Configuration
         /// Gets or sets a value indicating whether to update movie for the Check for Metadata Updates Scheduled Task.
         /// </summary>
         public bool UpdateMovieScheduledTask { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to update person for the Check for Metadata Updates Scheduled Task.
+        /// </summary>
+        public bool UpdatePersonScheduledTask { get; set; } = false;
     }
 }

--- a/Jellyfin.Plugin.Tvdb/Configuration/config.html
+++ b/Jellyfin.Plugin.Tvdb/Configuration/config.html
@@ -91,6 +91,10 @@
                         <input is="emby-checkbox" type="checkbox" id="updateMovieScheduledTask" />
                         <span>Update Movie</span>
                     </label>
+                    <label class="checkboxContainer">
+                        <input is="emby-checkbox" type="checkbox" id="updatePersonScheduledTask" />
+                        <span>Update Person</span>
+                    </label>
                     <div>
                         <button is="emby-button" type="submit" data-theme="b" class="raised button-submit block">
                             <span>Save</span>
@@ -126,6 +130,7 @@
                     document.getElementById('updateSeasonScheduledTask').checked = config.UpdateSeasonScheduledTask;
                     document.getElementById('updateEpisodeScheduledTask').checked = config.UpdateEpisodeScheduledTask;
                     document.getElementById('updateMovieScheduledTask').checked = config.UpdateMovieScheduledTask;
+                    document.getElementById('updatePersonScheduledTask').checked = config.UpdatePersonScheduledTask;
                     Dashboard.hideLoadingMsg();
                 });
             },
@@ -152,6 +157,7 @@
                     config.UpdateSeasonScheduledTask = document.getElementById('updateSeasonScheduledTask').checked;
                     config.UpdateEpisodeScheduledTask = document.getElementById('updateEpisodeScheduledTask').checked;
                     config.UpdateMovieScheduledTask = document.getElementById('updateMovieScheduledTask').checked;
+                    config.UpdatePersonScheduledTask = document.getElementById('updatePersonScheduledTask').checked;
 
                     ApiClient.updatePluginConfiguration(TvdbPluginConfiguration.uniquePluginId, config).then(function (result) {
                         Dashboard.processPluginConfigurationUpdateResult(result);


### PR DESCRIPTION
Tvdb Ids are not unique throughout the site. They are unique within its own catagory. As such, there might cause the wrong item to be refreshed, i.e a series tvdbid causing a person item to be refreshed. This changes ensures that the tvdbid search is done correctly in its own catagory.

Also added support for people updates.

I think this should be released as soon as it is merged.