### PR TITLE
Fix orphaned episodes deletion

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbMissingEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbMissingEpisodeProvider.cs
@@ -230,6 +230,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
             }
 
             var orphanedEpisodes = existingEpisodes
+                .Where(e => e.ParentIndexNumber == season.IndexNumber)
                 .Where(e => e.IsVirtualItem)
                 .Where(e => !seasonEpisodes.Any(episodeRecord => EpisodeEquals(e, episodeRecord)))
                 .ToList();


### PR DESCRIPTION
When using GetEpisodes of Season, specials with airs before or airs after set will be included as part of the season. Since the parent index of the specials does not match with the season number, the missing provider will think that it is an orphaned missing episode, thus deleting it. 

So to fix this, add an additional where clause to filter so that only the episodes with the parent index of the season is removed.