### PR TITLE
Added missing season type 'alttwo'

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbExternalUrlProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbExternalUrlProvider.cs
@@ -14,7 +14,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
     /// </summary>
     public class TvdbExternalUrlProvider : IExternalUrlProvider
     {
-        private readonly FrozenSet<string> _supportedOrders = new[] { "official", "regional", "alternate", "altdvd", "dvd", "absolute" }.ToFrozenSet();
+        private readonly FrozenSet<string> _supportedOrders = new[] { "official", "regional", "alternate", "altdvd", "dvd", "absolute", "alttwo" }.ToFrozenSet();
 
         /// <inheritdoc/>
         public string Name => TvdbPlugin.ProviderName;

--- a/Jellyfin.Plugin.Tvdb/TvdbClientManager.cs
+++ b/Jellyfin.Plugin.Tvdb/TvdbClientManager.cs
@@ -609,6 +609,7 @@ public class TvdbClientManager : IDisposable
                 case "alternate":
                 case "altdvd":
                 case "dvd":
+                case "alttwo":
                     episodeNumber = searchInfo.IndexNumber.Value;
                     seasonNumber = searchInfo.ParentIndexNumber.Value;
                     break;
@@ -656,6 +657,7 @@ public class TvdbClientManager : IDisposable
                 case "altdvd":
                 case "dvd":
                 case "absolute":
+                case "alttwo":
                     seriesResponse = await seriesClient.GetSeriesEpisodesAsync(page: 0, id: seriesTvdbId, season_type: searchInfo.SeriesDisplayOrder, season: seasonNumber, episodeNumber: episodeNumber, airDate: airDate, cancellationToken: cancellationToken).ConfigureAwait(false);
                     break;
                 default:


### PR DESCRIPTION
There are currently 7 types but here on jellyfin-plugin-tvdb only 6 are supported.
I've just added the one missing ^^

FYI: Here is the payload from thetvdb.com API v4 (seasons/types)

```
Swagger:
https://thetvdb.github.io/v4-api/
```

```
{
  "status": "success",
  "data": [
    {
      "id": 1,
      "name": "Aired Order",
      "type": "official",
      "alternateName": null
    },
    {
      "id": 2,
      "name": "DVD Order",
      "type": "dvd",
      "alternateName": null
    },
    {
      "id": 3,
      "name": "Absolute Order",
      "type": "absolute",
      "alternateName": null
    },
    {
      "id": 4,
      "name": "Alternate Order",
      "type": "alternate",
      "alternateName": null
    },
    {
      "id": 5,
      "name": "Regional Order",
      "type": "regional",
      "alternateName": null
    },
    {
      "id": 6,
      "name": "Alternate DVD Order",
      "type": "altdvd",
      "alternateName": null
    },
    {
      "id": 7,
      "name": "Alternate Order 2",
      "type": "alttwo",
      "alternateName": null
    }
  ]
}
```