### PR TITLE
Use season/episode TVDB IDs from path when available

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeImageProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeImageProvider.cs
@@ -58,49 +58,52 @@ namespace Jellyfin.Plugin.Tvdb.Providers
             var series = episode.Series;
             var imageResult = new List<RemoteImageInfo>();
             var language = item.GetPreferredMetadataLanguage();
-            if (series.IsSupported())
+
+            var episodeTvdbId = episode.GetTvdbId();
+
+            // Need either a direct episode ID or a supported series with an episode number
+            if (episodeTvdbId == 0 && (!series.IsSupported() || !episode.IndexNumber.HasValue))
             {
-                // Process images
-                try
+                return imageResult;
+            }
+
+            try
+            {
+                if (episodeTvdbId == 0)
                 {
-                    string? episodeTvdbId = null;
-
-                    if (episode.IndexNumber.HasValue)
+                    var episodeInfo = new EpisodeInfo
                     {
-                        var episodeInfo = new EpisodeInfo
-                        {
-                            IndexNumber = episode.IndexNumber.Value,
-                            ParentIndexNumber = episode.ParentIndexNumber,
-                            SeriesProviderIds = series.ProviderIds,
-                            SeriesDisplayOrder = series.DisplayOrder
-                        };
+                        IndexNumber = episode.IndexNumber!.Value,
+                        ParentIndexNumber = episode.ParentIndexNumber,
+                        SeriesProviderIds = series.ProviderIds,
+                        SeriesDisplayOrder = series.DisplayOrder
+                    };
 
-                        episodeTvdbId = await _tvdbClientManager
-                            .GetEpisodeTvdbId(episodeInfo, language, cancellationToken).ConfigureAwait(false);
-                    }
-
-                    if (string.IsNullOrEmpty(episodeTvdbId))
-                    {
-                        _logger.LogError(
-                            "Episode {SeasonNumber}x{EpisodeNumber} not found for series {SeriesTvdbId}:{Name}",
-                            episode.ParentIndexNumber,
-                            episode.IndexNumber,
-                            series.GetTvdbId(),
-                            series.Name);
-                        return imageResult;
-                    }
-
-                    var episodeResult =
-                        await _tvdbClientManager
-                            .GetEpisodesAsync(Convert.ToInt32(episodeTvdbId, CultureInfo.InvariantCulture), language, cancellationToken)
-                            .ConfigureAwait(false);
-
-                    imageResult.AddIfNotNull(episodeResult.CreateImageInfo(Name));
+                    var episodeTvdbIdStr = await _tvdbClientManager
+                        .GetEpisodeTvdbId(episodeInfo, language, cancellationToken).ConfigureAwait(false);
+                    episodeTvdbId = Convert.ToInt32(episodeTvdbIdStr, CultureInfo.InvariantCulture);
                 }
-                catch (Exception e)
+
+                if (episodeTvdbId == 0)
                 {
-                    _logger.LogError(e, "Failed to retrieve episode images for series {TvDbId}:{Name}", series.GetTvdbId(), series.Name);
+                    _logger.LogError(
+                        "Episode {SeasonNumber}x{EpisodeNumber} not found for series {SeriesTvdbId}:{Name}",
+                        episode.ParentIndexNumber,
+                        episode.IndexNumber,
+                        series.GetTvdbId(),
+                        series.Name);
+                    return imageResult;
                 }
+
+                var episodeResult = await _tvdbClientManager
+                    .GetEpisodesAsync(episodeTvdbId, language, cancellationToken)
+                    .ConfigureAwait(false);
+
+                imageResult.AddIfNotNull(episodeResult.CreateImageInfo(Name));
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Failed to retrieve episode images for series {TvDbId}:{Name}", series.GetTvdbId(), series.Name);
             }
 
             return imageResult;

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
@@ -83,8 +83,9 @@ namespace Jellyfin.Plugin.Tvdb.Providers
         /// <inheritdoc />
         public async Task<MetadataResult<Episode>> GetMetadata(EpisodeInfo info, CancellationToken cancellationToken)
         {
-            if ((info.IndexNumber == null && info.PremiereDate == null)
-                || !info.SeriesProviderIds.IsSupported())
+            // If no direct episode ID, require series identification and episode index/date to look up
+            if (info.GetTvdbId() == 0
+                && ((info.IndexNumber == null && info.PremiereDate == null) || !info.SeriesProviderIds.IsSupported()))
             {
                 _logger.LogDebug("No series identity found for {EpisodeName}", info.Name);
                 return new MetadataResult<Episode>
@@ -168,7 +169,7 @@ namespace Jellyfin.Plugin.Tvdb.Providers
             var episodeTvdbId = searchInfo.GetTvdbId().ToString(CultureInfo.InvariantCulture);
             try
             {
-                if (string.Equals(episodeTvdbId, "0", StringComparison.OrdinalIgnoreCase) || ignoreTvdbIdField || searchInfo.IsAutomated)
+                if (string.Equals(episodeTvdbId, "0", StringComparison.OrdinalIgnoreCase) || ignoreTvdbIdField)
                 {
                     episodeTvdbId = await _tvdbClientManager
                         .GetEpisodeTvdbId(searchInfo, searchInfo.MetadataLanguage, cancellationToken)

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbSeasonImageProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbSeasonImageProvider.cs
@@ -69,7 +69,7 @@ public class TvdbSeasonImageProvider : IRemoteImageProvider
         var season = (Season)item;
         var series = season.Series;
 
-        if (!series.IsSupported() || season.IndexNumber is null)
+        if (!season.HasTvdbId() && (!series.IsSupported() || season.IndexNumber is null))
         {
             return Enumerable.Empty<RemoteImageInfo>();
         }
@@ -87,7 +87,8 @@ public class TvdbSeasonImageProvider : IRemoteImageProvider
             .ToDictionary(t => t.Id!.Value);
 
         var seriesTvdbId = series.GetTvdbId();
-        var seasonNumber = season.IndexNumber.Value;
+        var seasonTvdbId = season.GetTvdbId();
+        var seasonNumber = season.IndexNumber ?? 0;
         var displayOrder = season.Series.DisplayOrder;
 
         if (string.IsNullOrEmpty(displayOrder))
@@ -95,7 +96,7 @@ public class TvdbSeasonImageProvider : IRemoteImageProvider
             displayOrder = "official";
         }
 
-        var seasonArtworks = await GetSeasonArtworks(seriesTvdbId, seasonNumber, displayOrder, cancellationToken)
+        var seasonArtworks = await GetSeasonArtworks(seasonTvdbId, seriesTvdbId, seasonNumber, displayOrder, cancellationToken)
             .ConfigureAwait(false);
 
         var remoteImages = new List<RemoteImageInfo>();
@@ -112,39 +113,69 @@ public class TvdbSeasonImageProvider : IRemoteImageProvider
         return remoteImages.OrderByLanguageDescending(item.GetPreferredMetadataLanguage());
     }
 
-    private async Task<IReadOnlyList<ArtworkBaseRecord>> GetSeasonArtworks(int seriesTvdbId, int seasonNumber, string displayOrder, CancellationToken cancellationToken)
+    private async Task<IReadOnlyList<ArtworkBaseRecord>> GetSeasonArtworks(int seasonTvdbId, int seriesTvdbId, int seasonNumber, string displayOrder, CancellationToken cancellationToken)
     {
         try
         {
-            var seriesInfo = await _tvdbClientManager.GetSeriesExtendedByIdAsync(seriesTvdbId, string.Empty, cancellationToken, small: true)
-                .ConfigureAwait(false);
-            // Get the season information for the particular display order and aired order display order
-            // Ensure that the aired order is always last in the list
-            var seasonBaseList = seriesInfo.Seasons.Where(s => s.Number == seasonNumber && (s.Type.Type == displayOrder || s.Type.Type == "official" )).OrderBy(s => s.Type.Type == "official");
+            var officialFallbackId = 0;
 
-            var seasonTvdbId = seasonBaseList?.FirstOrDefault()?.Id;
-            var seasonInfo = await _tvdbClientManager.GetSeasonByIdAsync(seasonTvdbId ?? 0, string.Empty, cancellationToken)
-                .ConfigureAwait(false);
-
-            // If no image are found for the particular display order and the display order is not aired order,
-            // try to get the aired order images
-            if ((seasonInfo.Artwork is null || seasonInfo.Artwork.Count == 0)
-                && !string.Equals(displayOrder, "official", StringComparison.OrdinalIgnoreCase))
+            // Do the series lookup if we need to find the season ID
+            if (seasonTvdbId == 0)
             {
-               seasonTvdbId = seasonBaseList?.Skip(1).FirstOrDefault()?.Id;
-               seasonInfo = await _tvdbClientManager.GetSeasonByIdAsync(seasonTvdbId ?? 0, string.Empty, cancellationToken)
-                 .ConfigureAwait(false);
+                var seasonsByNumber = await GetSeriesSeasonsByNumberAsync(seriesTvdbId, seasonNumber, cancellationToken)
+                    .ConfigureAwait(false);
+
+                seasonTvdbId = seasonsByNumber
+                    .FirstOrDefault(s => s.Type.Type == displayOrder)?.Id ?? 0;
+
+                officialFallbackId = seasonsByNumber
+                    .FirstOrDefault(s => s.Type.Type == "official")?.Id ?? 0;
             }
 
-            return seasonInfo.Artwork ?? Enumerable.Empty<ArtworkBaseRecord>().ToList();
+            var seasonInfo = await _tvdbClientManager.GetSeasonByIdAsync(seasonTvdbId, string.Empty, cancellationToken)
+                .ConfigureAwait(false);
+
+            // If no images found for the requested display order, fall back to the official order
+            if (seasonInfo.Artwork is null || seasonInfo.Artwork.Count == 0)
+            {
+                // lazy lookup of the official season ID if we didn't already have it from the initial lookup by season number and display order
+                if (officialFallbackId == 0)
+                {
+                    var seasonsByNumber = await GetSeriesSeasonsByNumberAsync(seriesTvdbId, seasonNumber, cancellationToken)
+                        .ConfigureAwait(false);
+                    officialFallbackId = seasonsByNumber.FirstOrDefault(s => s.Type.Type == "official")?.Id ?? 0;
+                }
+
+                if (officialFallbackId != seasonTvdbId)
+                {
+                    seasonInfo = await _tvdbClientManager.GetSeasonByIdAsync(officialFallbackId, string.Empty, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            }
+
+            if (seasonInfo.Artwork is not null)
+            {
+                return seasonInfo.Artwork;
+            }
         }
         catch (Exception ex) when (
             (ex is SeriesException seriesEx && seriesEx.InnerException is JsonException)
             || (ex is SeasonsException seasonEx && seasonEx.InnerException is JsonException))
         {
             _logger.LogError(ex, "Failed to retrieve season images for series {TvDbId}", seriesTvdbId);
-            return Array.Empty<ArtworkBaseRecord>();
         }
+
+        return Array.Empty<ArtworkBaseRecord>();
+    }
+
+    private async Task<IReadOnlyList<SeasonBaseRecord>> GetSeriesSeasonsByNumberAsync(int seriesTvdbId, int seasonNumber, CancellationToken cancellationToken)
+    {
+        var seriesInfo = await _tvdbClientManager.GetSeriesExtendedByIdAsync(seriesTvdbId, string.Empty, cancellationToken, small: true)
+            .ConfigureAwait(false);
+
+        return seriesInfo.Seasons
+            .Where(s => s.Number == seasonNumber)
+            .ToList();
     }
 
     /// <inheritdoc />

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbSeasonProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbSeasonProvider.cs
@@ -52,21 +52,22 @@ namespace Jellyfin.Plugin.Tvdb.Providers
         /// <inheritdoc/>
         public async Task<MetadataResult<Season>> GetMetadata(SeasonInfo info, CancellationToken cancellationToken)
         {
-            if (info.IndexNumber == null || !info.SeriesProviderIds.IsSupported())
+            int? seasonId = info.GetTvdbId();
+
+            // If no direct season ID, require series identification and season number to look up
+            if (seasonId == 0 && (info.IndexNumber == null || !info.SeriesProviderIds.IsSupported()))
             {
-                _logger.LogDebug("No series identity found for {EpisodeName}", info.Name);
+                _logger.LogDebug("No series identity found for {SeasonName}", info.Name);
                 return new MetadataResult<Season>
                 {
                     QueriedById = true
                 };
             }
 
-            int? seasonId = info.GetTvdbId();
             string displayOrder = info.SeriesDisplayOrder;
 
             // If the seasonId is 0, it means the season is not yet identified and we need to find it
-            // If IsAutomated is true, it means that the order has changed and we need to find the new season id
-            if (seasonId == 0 || info.IsAutomated)
+            if (seasonId == 0)
             {
                 if (string.IsNullOrWhiteSpace(displayOrder))
                 {


### PR DESCRIPTION
When the Jellyfin core resolvers parse a provider ID from a folder or file name (e.g. `Season 1 [tvdbid-12345]`), the ID is now stored in the item's ProviderIds before metadata providers run.

This change makes the TVDB plugin use those stored IDs (which also can be changed in metadata edit) directly rather than always requiring a full series lookup. 

- TvdbSeasonProvider: use season ID directly if present; only fall back to series lookup when no ID is available. Removes the IsAutomated re-fetch so that path-supplied IDs are always honoured (see PR notes).
- TvdbSeasonImageProvider: use season ID directly to skip the series fetch for the primary season; lazy-fetch the series only when needed for the official-order artwork fallback.

- TvdbEpisodeProvider: same pattern for episodes; removes IsAutomated re-fetch.
- TvdbEpisodeImageProvider: use episode ID directly to skip the expensive GetEpisodeTvdbId series+number lookup.

Note: removing the IsAutomated re-fetch means that changing a series' display order will no longer automatically update stored season IDs. Users would need to manually clear the TVDB ID from affected seasons to force re-discovery. This is an intentional trade-off to ensure path-supplied IDs are always respected.

This builds on the [Main Jellyfin PR #16472](https://github.com/jellyfin/jellyfin/pull/16472)