### PR TITLE
Work around TVDB API bug for altdvd / alttwo season types (fixes #226)

### DIFF
--- a/Jellyfin.Plugin.Tvdb/TvdbClientManager.cs
+++ b/Jellyfin.Plugin.Tvdb/TvdbClientManager.cs
@@ -15,6 +15,7 @@ using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Globalization;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Tvdb.Sdk;
 
 using Action = Tvdb.Sdk.Action;
@@ -34,6 +35,7 @@ public class TvdbClientManager : IDisposable
     private readonly IServiceProvider _serviceProvider;
     private readonly MemoryCache _memoryCache;
     private readonly SdkClientSettings _sdkClientSettings;
+    private readonly ILogger<TvdbClientManager> _logger;
 
     private DateTime _tokenUpdatedAt;
 
@@ -42,8 +44,10 @@ public class TvdbClientManager : IDisposable
     /// </summary>
     /// <param name="applicationHost">Instance of the <see cref="IApplicationHost"/> interface.</param>
     /// <param name="localizationManager">Instance of the <see cref="ILocalizationManager"/> interface.</param>
-    public TvdbClientManager(IApplicationHost applicationHost, ILocalizationManager localizationManager)
+    /// <param name="logger">Instance of the <see cref="ILogger{TvdbClientManager}"/> interface.</param>
+    public TvdbClientManager(IApplicationHost applicationHost, ILocalizationManager localizationManager, ILogger<TvdbClientManager> logger)
     {
+        _logger = logger;
         _serviceProvider = ConfigureService(applicationHost);
         _httpClientFactory = _serviceProvider.GetRequiredService<IHttpClientFactory>();
         _sdkClientSettings = _serviceProvider.GetRequiredService<SdkClientSettings>();
@@ -293,10 +297,110 @@ public class TvdbClientManager : IDisposable
 
         var seriesClient = _serviceProvider.GetRequiredService<ISeriesClient>();
         await LoginAsync().ConfigureAwait(false);
+        _logger.LogDebug("TvdbApiWorkaround.GetSeriesEpisodesAsync: requesting series {TvdbId} with seasonType '{SeasonType}' from upstream API.", tvdbId, seasonType);
         var seriesResult = await seriesClient.GetSeriesEpisodesAsync(id: tvdbId, season_type: seasonType, cancellationToken: cancellationToken, page: 0)
             .ConfigureAwait(false);
-        _memoryCache.Set(key, seriesResult.Data, TimeSpan.FromHours(CacheDurationInHours));
-        return seriesResult.Data;
+        var data = seriesResult.Data;
+        var primaryCount = data?.Episodes?.Count ?? 0;
+        _logger.LogDebug("TvdbApiWorkaround.GetSeriesEpisodesAsync: upstream returned {Count} episodes for series {TvdbId} seasonType '{SeasonType}'.", primaryCount, tvdbId, seasonType);
+
+        // Workaround for https://github.com/thetvdb/v4-api/issues/340: the TVDB v4 API
+        // returns an empty episodes array for the "altdvd" and "alttwo" season types,
+        // even though the season records themselves exist. When the primary endpoint
+        // returns nothing, fall back to walking the extended series record's Seasons
+        // list and aggregating the episodes from each matching season.
+        if (data is not null && primaryCount == 0)
+        {
+            var aggregated = await TryAggregateEpisodesPerSeasonAsync(tvdbId, language, seasonType, cancellationToken).ConfigureAwait(false);
+            if (aggregated.Count > 0)
+            {
+                _logger.LogInformation("TvdbApiWorkaround: aggregated {Count} episodes for series {TvdbId} season type '{SeasonType}' via per-season fallback (upstream API bug thetvdb/v4-api#340).", aggregated.Count, tvdbId, seasonType);
+                data.Episodes = aggregated;
+            }
+        }
+
+        _memoryCache.Set(key, data, TimeSpan.FromHours(CacheDurationInHours));
+        return data!;
+    }
+
+    /// <summary>
+    /// Workaround for https://github.com/thetvdb/v4-api/issues/340. Fetches the extended
+    /// series record, filters the seasons by the requested type and pulls each matching
+    /// season's extended record to collect its episodes. Returns an empty list if the
+    /// series has no seasons of that type or the API calls fail.
+    /// </summary>
+    /// <param name="tvdbId">The series tvdb id.</param>
+    /// <param name="language">Metadata language.</param>
+    /// <param name="seasonType">Season type slug (e.g. <c>altdvd</c>, <c>alttwo</c>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The aggregated episode list, in season-number order.</returns>
+    private async Task<IReadOnlyList<EpisodeBaseRecord>> TryAggregateEpisodesPerSeasonAsync(
+        int tvdbId,
+        string language,
+        string seasonType,
+        CancellationToken cancellationToken)
+    {
+        SeriesExtendedRecord? seriesExtended;
+        try
+        {
+            seriesExtended = await GetSeriesExtendedByIdAsync(tvdbId, language, cancellationToken, small: true).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "TvdbApiWorkaround: failed to fetch extended series record for {TvdbId}.", tvdbId);
+            return Array.Empty<EpisodeBaseRecord>();
+        }
+
+        var allSeasons = seriesExtended?.Seasons;
+        var allSeasonsCount = allSeasons?.Count ?? 0;
+        var distinctTypeSlugs = allSeasons?
+            .Where(s => s?.Type?.Type is not null)
+            .Select(s => s.Type!.Type)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList() ?? new List<string>();
+        _logger.LogDebug("TvdbApiWorkaround.Aggregate: series {TvdbId} extended record has {Total} seasons, distinct type slugs: [{Slugs}]; filtering for '{Wanted}'.", tvdbId, allSeasonsCount, string.Join(", ", distinctTypeSlugs), seasonType);
+
+        var matchingSeasons = allSeasons?
+            .Where(s => s?.Type is not null
+                && string.Equals(s.Type.Type, seasonType, StringComparison.OrdinalIgnoreCase)
+                && s.Id.HasValue)
+            .OrderBy(s => s.Number ?? 0)
+            .ToList();
+
+        if (matchingSeasons is null || matchingSeasons.Count == 0)
+        {
+            _logger.LogWarning("TvdbApiWorkaround.Aggregate: no seasons of type '{Wanted}' found for series {TvdbId}; returning empty list.", seasonType, tvdbId);
+            return Array.Empty<EpisodeBaseRecord>();
+        }
+
+        _logger.LogDebug("TvdbApiWorkaround.Aggregate: found {Count} season(s) of type '{Wanted}' for series {TvdbId}; ids=[{Ids}].", matchingSeasons.Count, seasonType, tvdbId, string.Join(", ", matchingSeasons.Select(s => s.Id!.Value)));
+
+        var aggregated = new List<EpisodeBaseRecord>();
+        foreach (var season in matchingSeasons)
+        {
+            try
+            {
+                var seasonRecord = await GetSeasonByIdAsync(season.Id!.Value, language, cancellationToken).ConfigureAwait(false);
+                var perSeasonCount = seasonRecord?.Episodes?.Count ?? 0;
+                _logger.LogDebug("TvdbApiWorkaround.Aggregate: season {SeasonId} (number {SeasonNumber}) returned {Count} episodes.", season.Id, season.Number, perSeasonCount);
+                if (seasonRecord?.Episodes is not null && seasonRecord.Episodes.Count > 0)
+                {
+                    // /seasons/{id}/extended returns each episode's seasonNumber and number
+                    // in the alternate-order numbering (verified against the TVDB v4 API
+                    // and the public web UI: the values match what the "Alternate DVD Order"
+                    // tab shows on thetvdb.com for the corresponding season type). The
+                    // array order itself is not the alternate-order position, but the
+                    // per-episode fields are correct for SxE matching downstream.
+                    aggregated.AddRange(seasonRecord.Episodes);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "TvdbApiWorkaround: failed to fetch extended season {SeasonId} for series {TvdbId}.", season.Id, tvdbId);
+            }
+        }
+
+        return aggregated;
     }
 
     /// <summary>
@@ -587,6 +691,7 @@ public class TvdbClientManager : IDisposable
         string language,
         CancellationToken cancellationToken)
     {
+        _logger.LogDebug("TvdbApiWorkaround.GetEpisodeTvdbId: invoked. SeriesDisplayOrder='{Order}', ParentIndex={ParentIndex}, Index={Index}, Premiere={Premiere}, IsAutomated={IsAutomated}.", searchInfo.SeriesDisplayOrder, searchInfo.ParentIndexNumber, searchInfo.IndexNumber, searchInfo.PremiereDate, searchInfo.IsAutomated);
         var seriesClient = _serviceProvider.GetRequiredService<ISeriesClient>();
         await LoginAsync().ConfigureAwait(false);
         if (!searchInfo.SeriesProviderIds.TryGetValue(TvdbPlugin.ProviderId, out var seriesTvdbIdString))
@@ -645,6 +750,36 @@ public class TvdbClientManager : IDisposable
         if (key != null && _memoryCache.TryGetValue(key, out string? episodeTvdbId))
         {
             return episodeTvdbId;
+        }
+
+        // Workaround for https://github.com/thetvdb/v4-api/issues/340: the TVDB
+        // filter-by-season/episode endpoint also returns empty results for the
+        // altdvd and alttwo season types, not just the unfiltered bulk endpoint.
+        // For those season types, route through GetSeriesEpisodesAsync (which
+        // applies the per-season fallback) and resolve the match locally.
+        if (!special
+            && (string.Equals(searchInfo.SeriesDisplayOrder, "altdvd", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(searchInfo.SeriesDisplayOrder, "alttwo", StringComparison.OrdinalIgnoreCase)))
+        {
+            var bulkData = await GetSeriesEpisodesAsync(seriesTvdbId, language, searchInfo.SeriesDisplayOrder!, cancellationToken).ConfigureAwait(false);
+            var match = bulkData?.Episodes?.FirstOrDefault(e =>
+            {
+                if (seasonNumber.HasValue && episodeNumber.HasValue)
+                {
+                    return e.SeasonNumber == seasonNumber.Value && e.Number == episodeNumber.Value;
+                }
+
+                return !string.IsNullOrEmpty(airDate) && string.Equals(e.Aired, airDate, StringComparison.OrdinalIgnoreCase);
+            });
+
+            var resolvedId = match?.Id?.ToString(CultureInfo.InvariantCulture);
+            _logger.LogDebug("TvdbApiWorkaround.GetEpisodeTvdbId: altdvd/alttwo branch resolved series {Tvdb} S{S}E{E} -> {Resolved}.", seriesTvdbId, seasonNumber, episodeNumber, resolvedId ?? "<null>");
+            if (key != null)
+            {
+                _memoryCache.Set(key, resolvedId, TimeSpan.FromHours(CacheDurationInHours));
+            }
+
+            return resolvedId;
         }
 
         Response56 seriesResponse;


### PR DESCRIPTION
## Summary

Resolves #226 by working around [thetvdb/v4-api#340](https://github.com/thetvdb/v4-api/issues/340) where the TVDB v4 API returns an empty `episodes` array for the `altdvd` and `alttwo` season types, even though the corresponding season records exist and the public TVDB web UI shows them correctly. The upstream API bug has been open since late 2023 with no movement, so handling it client-side seems to be the only path forward.

## Approach

This builds on the per-season fallback approach proposed by @iampegram in #242. When the primary `GetSeriesEpisodesAsync` call comes back empty, walk the extended series record, filter `Seasons` by `SeasonType.Type`, and aggregate each matching season's `Episodes` via the existing `IExtendedSeasonClient` (`GetSeasonByIdAsync`). No new DI wiring is needed.

The same workaround is also applied at the `GetEpisodeTvdbId` entry point. The SDK's filter-by-SxE variant of the bulk endpoint is broken for the same season types, so `TvdbEpisodeProvider.GetEpisode` was falling through to the \"Episode SxxExx not found\" log path even when the per-season data would have resolved correctly. Routing altdvd / alttwo through the workaround-aware bulk fetch and matching locally fixes the per-episode resolution.

The per-episode `seasonNumber` / `number` fields returned by `/seasons/{id}/extended` are already populated in the alternate-order numbering (matching what the *Alternate DVD Order* tab shows on thetvdb.com for the queried season type), so SxE matching on the aggregated list is straightforward.

## Verification

End-to-end on a real Jellyfin 10.11.x install against series 75886 (SpongeBob SquarePants), with the *Alternate DVD Order* display setting:

| Library file | Resolved tvdb id | Title |
|---|---|---|
| altdvd-S2E1 | 9289284 | Your Shoe's Untied / Squid's Day Off |
| altdvd-S2E8 | 1065131 | The SpongeBob Christmas Special |
| altdvd-S2E11 | 9289295 | Mermaid Man and Barnacle Boy III / Squirrel Jokes |
| altdvd-S2E19 | 9289303 | Jellyfish Hunter / The Fry Cook Games |

All matches were cross-verified against the *Alternate DVD Order* tab at https://thetvdb.com/series/spongebob-squarepants .

## Why a new PR rather than continuing #242

#242 has been open since March without review and contains compile-time errors that prevented it from being mergeable (`s.Type = seasonType` assignment instead of comparison; `_serviceProvider.GetRequiredService<ISeasonsClient>()` against a type that isn't registered with the DI container, which would also throw at runtime even after the comparison was fixed). I tried to keep this PR a clean re-implementation rather than force-pushing over @iampegram's branch, so credit and discussion history are preserved.

## Credits

Thanks to everyone who triaged this issue:

- @foclabroc for filing #226 and reporting the altdvd regression
- @drrlvn for independently reporting the same problem for alttwo
- @InfiniteLoopGameDev for pointing at the upstream API issue
- @iampegram for proposing and prototyping the per-season fallback approach in #242
- @TheMelmacian for validating that approach against the API spec

## Test plan

- [x] dotnet build passes with `TreatWarningsAsErrors` and the existing StyleCop / nullability analyzers.
- [x] Pre-existing aired / dvd / absolute display-order paths are unchanged (the workaround only fires when the primary endpoint returns empty).
- [x] Verified against the live TVDB v4 API for series 75886, all altdvd-S2 episode positions resolve to the expected tvdb ids.
- [x] Verified end-to-end in Jellyfin 10.11.x: titles, overviews and images for altdvd-ordered episodes now match the *Alternate DVD Order* tab on thetvdb.com .