### PR TITLE
Assign season and episode numbers for daily shows

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbEpisodeProvider.cs
@@ -212,8 +212,8 @@ namespace Jellyfin.Plugin.Tvdb.Providers
                 HasMetadata = true,
                 Item = new Episode
                 {
-                    IndexNumber = id.IndexNumber,
-                    ParentIndexNumber = id.ParentIndexNumber ?? 1,
+                    IndexNumber = id.IndexNumber ?? episode.Number,
+                    ParentIndexNumber = id.ParentIndexNumber ?? episode.SeasonNumber ?? 1,
                     IndexNumberEnd = id.IndexNumberEnd,
                     // Tvdb uses 3 letter code for language (prob ISO 639-2)
                     // Reverts to OriginalName if no translation is found


### PR DESCRIPTION
Fall back to the resolved episode's season/episode number when the input has none.

Fixes: https://github.com/jellyfin/jellyfin/issues/15636
Fixes: https://github.com/jellyfin/jellyfin/issues/1398
Fixes #245