### PR TITLE
Option to import for original title

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Tvdb/Configuration/PluginConfiguration.cs
@@ -47,6 +47,11 @@ namespace Jellyfin.Plugin.Tvdb.Configuration
         public string FallbackLanguages { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets a value indicating whether to import orignal title.
+        /// </summary>
+        public bool OriginalTitle { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets a value indicating whether to import season name.
         /// </summary>
         public bool ImportSeasonName { get; set; } = false;

--- a/Jellyfin.Plugin.Tvdb/Configuration/config.html
+++ b/Jellyfin.Plugin.Tvdb/Configuration/config.html
@@ -43,6 +43,10 @@
                         </div>
                     </div>
                     <label class="checkboxContainer">
+                        <input is="emby-checkbox" type="checkbox" id="originalTitle" />
+                        <span>Import Original Title for Movie/Series. Allows other lower ranked provider to set original title.</span>
+                    </label>
+                    <label class="checkboxContainer">
                         <input is="emby-checkbox" type="checkbox" id="importSeasonName" />
                         <span>Import season name from provider</span>
                     </label>
@@ -116,7 +120,8 @@
                     document.getElementById('cacheDurationInHours').value = config.CacheDurationInHours;
                     document.getElementById('cacheDurationInDays').value = config.CacheDurationInDays;
                     document.getElementById('fallbackLanguages').value = config.FallbackLanguages;
-                    document.getElementById('importSeasonName').checked = config.ImportSeasonName
+                    document.getElementById('importSeasonName').checked = config.ImportSeasonName;
+                    document.getElementById('originalTitle').checked = config.OriginalTitle;
                     document.getElementById('fallbackToOriginalLanguage').checked = config.FallbackToOriginalLanguage;
                     document.getElementById('includeOriginalCountryInTags').checked = config.IncludeOriginalCountryInTags;
                   
@@ -144,6 +149,7 @@
                     config.CacheDurationInDays = document.getElementById('cacheDurationInDays').value;
                     config.FallbackLanguages = document.getElementById('fallbackLanguages').value;
                     config.ImportSeasonName = document.getElementById('importSeasonName').checked;
+                    config.OriginalTitle = document.getElementById('originalTitle').checked;
                     config.FallbackToOriginalLanguage = document.getElementById('fallbackToOriginalLanguage').checked;
                     config.IncludeOriginalCountryInTags = document.getElementById('includeOriginalCountryInTags').checked;
                   

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbMovieProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbMovieProvider.cs
@@ -55,6 +55,8 @@ namespace Jellyfin.Plugin.Tvdb.Providers
 
         private static bool IncludeOriginalCountryInTags => TvdbPlugin.Instance?.Configuration.IncludeOriginalCountryInTags ?? false;
 
+        private static bool OriginalTitle => TvdbPlugin.Instance?.Configuration.OriginalTitle ?? false;
+
         /// <inheritdoc/>
         public async Task<IEnumerable<RemoteSearchResult>> GetSearchResults(MovieInfo searchInfo, CancellationToken cancellationToken)
         {
@@ -402,7 +404,12 @@ namespace Jellyfin.Plugin.Tvdb.Providers
             // Reverts to OriginalName if no translation is found
             movie.Name = tvdbMovie.Translations.GetTranslatedNamedOrDefault(info.MetadataLanguage) ?? TvdbUtils.ReturnOriginalLanguageOrDefault(tvdbMovie.Name);
             movie.Overview = tvdbMovie.Translations.GetTranslatedOverviewOrDefault(info.MetadataLanguage);
-            movie.OriginalTitle = tvdbMovie.Name;
+
+            if (OriginalTitle)
+            {
+                movie.OriginalTitle = tvdbMovie.Name;
+            }
+
             result.ResultLanguage = info.MetadataLanguage;
             // Attempts to default to USA if not found
             movie.OfficialRating = tvdbMovie.ContentRatings?.FirstOrDefault(x => string.Equals(x.Country, TvdbCultureInfo.GetCountryInfo(info.MetadataCountryCode)?.ThreeLetterISORegionName, StringComparison.OrdinalIgnoreCase))?.Name ?? tvdbMovie.ContentRatings?.FirstOrDefault(x => string.Equals(x.Country, "usa", StringComparison.OrdinalIgnoreCase))?.Name;

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbSeriesProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbSeriesProvider.cs
@@ -51,6 +51,8 @@ namespace Jellyfin.Plugin.Tvdb.Providers
 
         private static bool IncludeOriginalCountryInTags => TvdbPlugin.Instance?.Configuration.IncludeOriginalCountryInTags ?? false;
 
+        private static bool OriginalTitle => TvdbPlugin.Instance?.Configuration.OriginalTitle ?? false;
+
         /// <inheritdoc />
         public async Task<IEnumerable<RemoteSearchResult>> GetSearchResults(SeriesInfo searchInfo, CancellationToken cancellationToken)
         {
@@ -442,9 +444,14 @@ namespace Jellyfin.Plugin.Tvdb.Providers
             series.SetTvdbId(tvdbSeries.Id);
             // Tvdb uses 3 letter code for language (prob ISO 639-2)
             // Reverts to OriginalName if no translation is found
-            series.Name = tvdbSeries.Translations.GetTranslatedNamedOrDefault(info.MetadataLanguage) ?? TvdbUtils.ReturnOriginalLanguageOrDefault(tvdbSeries.Name);
             series.Overview = tvdbSeries.Translations.GetTranslatedOverviewOrDefault(info.MetadataLanguage) ?? TvdbUtils.ReturnOriginalLanguageOrDefault(tvdbSeries.Overview);
-            series.OriginalTitle = tvdbSeries.Name;
+
+            if (OriginalTitle)
+            {
+                series.Name = tvdbSeries.Translations.GetTranslatedNamedOrDefault(info.MetadataLanguage) ?? TvdbUtils.ReturnOriginalLanguageOrDefault(tvdbSeries.Name);
+                series.OriginalTitle = tvdbSeries.Name;
+            }
+
             result.ResultLanguage = info.MetadataLanguage;
             series.AirDays = TvdbUtils.GetAirDays(tvdbSeries.AirsDays).ToArray();
             series.AirTime = tvdbSeries.AirsTime;


### PR DESCRIPTION
**Background**
- TVDB is often sued for layout
- Asian languages like Japanese have Localized title, Original in Kanji and Romaji and often used in communities https://en.wikipedia.org/wiki/Romanization_of_Japanese
- TVDB only provides Japanese title

**PR**
- Then the import is disabled (default on), plugin like anidb can write the title and the plugin provides a select to choose preferred version

No LLM used

fixes #261