### PR TITLE
Fix identification of titles containing punctuation

### DIFF
--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbMovieProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbMovieProvider.cs
@@ -218,12 +218,14 @@ namespace Jellyfin.Plugin.Tvdb.Providers
             IReadOnlyList<SearchResult> result;
             try
             {
-                result = await _tvdbClientManager.GetMovieByNameAsync(comparableName, cancellationToken)
+                result = await TvdbUtils.SearchByNameAsync(
+                        parsedName.Name,
+                        query => _tvdbClientManager.GetMovieByNameAsync(query, cancellationToken))
                     .ConfigureAwait(false);
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "No movie results found for {Name}", comparableName);
+                _logger.LogError(e, "No movie results found for {Name}", parsedName.Name);
                 return new List<RemoteSearchResult>();
             }
 

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbPersonProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbPersonProvider.cs
@@ -196,12 +196,14 @@ namespace Jellyfin.Plugin.Tvdb.Providers
             IReadOnlyList<SearchResult> result;
             try
             {
-                result = await _tvdbClientManager.GetActorByNameAsync(comparableName, cancellationToken)
+                result = await TvdbUtils.SearchByNameAsync(
+                        parsedName.Name,
+                        query => _tvdbClientManager.GetActorByNameAsync(query, cancellationToken))
                     .ConfigureAwait(false);
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "No person results found for {Name}", comparableName);
+                _logger.LogError(e, "No person results found for {Name}", parsedName.Name);
                 return new List<RemoteSearchResult>();
             }
 

--- a/Jellyfin.Plugin.Tvdb/Providers/TvdbSeriesProvider.cs
+++ b/Jellyfin.Plugin.Tvdb/Providers/TvdbSeriesProvider.cs
@@ -317,12 +317,14 @@ namespace Jellyfin.Plugin.Tvdb.Providers
             IReadOnlyList<SearchResult> result;
             try
             {
-                result = await _tvdbClientManager.GetSeriesByNameAsync(comparableName, language, cancellationToken)
+                result = await TvdbUtils.SearchByNameAsync(
+                        parsedName.Name,
+                        query => _tvdbClientManager.GetSeriesByNameAsync(query, language, cancellationToken))
                     .ConfigureAwait(false);
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "No series results found for {Name}", comparableName);
+                _logger.LogError(e, "No series results found for {Name}", parsedName.Name);
                 return new List<RemoteSearchResult>();
             }
 

--- a/Jellyfin.Plugin.Tvdb/TvdbUtils.cs
+++ b/Jellyfin.Plugin.Tvdb/TvdbUtils.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Tvdb.Sdk;
 
 namespace Jellyfin.Plugin.Tvdb
@@ -87,6 +88,34 @@ namespace Jellyfin.Plugin.Tvdb
             name = Regex.Replace(name, @"[\p{Lm}\p{Mn}]", string.Empty); // Remove diacritics, etc
             name = Regex.Replace(name, @"[\W\p{Pc}]+", " "); // Replace sequences of non-word characters and _ with " "
             return name.Trim();
+        }
+
+        /// <summary>
+        /// Searches Tvdb for a name, falling back to its comparable form if nothing was found.
+        /// </summary>
+        /// <param name="name">The name of the item, as parsed from its path.</param>
+        /// <param name="search">Performs the search for a single query string.</param>
+        /// <returns>The search results, empty if neither query matched anything.</returns>
+        public static async Task<IReadOnlyList<SearchResult>> SearchByNameAsync(
+            string name,
+            Func<string, Task<IReadOnlyList<SearchResult>>> search)
+        {
+            ArgumentNullException.ThrowIfNull(search);
+
+            // Tvdb matches a title as it is written, so the name is searched for unchanged first.
+            // Its comparable form is only a fallback, because collapsing punctuation to spaces
+            // splits a word in two.
+            var results = await search(name).ConfigureAwait(false);
+            if (results.Count > 0)
+            {
+                return results;
+            }
+
+            var comparableName = GetComparableName(name);
+
+            return string.Equals(name, comparableName, StringComparison.OrdinalIgnoreCase)
+                ? results
+                : await search(comparableName).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
`GetComparableName` collapses punctuation to spaces, and that string was sent straight to TVDB as the search query. TVDB matches titles as written and returns nothing once a word is split in two, so every title with an apostrophe failed to identify:

  | query sent | results |
  | --- | --- |
  | `dawson s creek` | 0 |
  | `Dawson's Creek` | 2 |
  | `dawsons creek` | 2 |

Series, movie and person search were all affected (`schindler s list`, `conan o brien` → 0 results too).

`TvdbUtils.SearchByNameAsync` now searches for the parsed name unchanged and only falls back to the comparable form when that finds nothing, so titles that the reduced form does help with keep working. The comparable name is still used for result ranking.

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/17855